### PR TITLE
Add node:test for getBugImage

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "lint": "eslint src --ext ts,tsx"
+    "lint": "eslint src --ext ts,tsx",
+    "test": "node --experimental-transform-types --loader ./png-loader.js --test"
   },
   "dependencies": {
     "@radix-ui/react-navigation-menu": "^1.2.10",

--- a/png-loader.js
+++ b/png-loader.js
@@ -1,0 +1,17 @@
+export async function resolve(specifier, context, defaultResolve) {
+  if (specifier.endsWith('.png')) {
+    return { url: new URL(specifier, context.parentURL).href, shortCircuit: true };
+  }
+  return defaultResolve(specifier, context, defaultResolve);
+}
+
+export async function load(url, context, defaultLoad) {
+  if (url.endsWith('.png')) {
+    return {
+      format: 'module',
+      source: `export default ${JSON.stringify(url)};`,
+      shortCircuit: true,
+    };
+  }
+  return defaultLoad(url, context, defaultLoad);
+}

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -1,0 +1,10 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { getBugImage } from './utils.ts';
+
+test('getBugImage returns consistent image for identical bug IDs', () => {
+  const id = 'bug-id-123';
+  const first = getBugImage(id);
+  const second = getBugImage(id);
+  assert.strictEqual(second, first);
+});


### PR DESCRIPTION
## Summary
- configure npm script to run Node's test runner with a custom loader
- add `png-loader.js` to stub PNG imports when testing
- add `src/utils/utils.test.ts` verifying that repeated calls with a bug id return the same image

## Testing
- `npm run test`
