### PR TITLE
Add deployment badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # React + TypeScript + Vite
 
+[![Vercel](https://img.shields.io/badge/Vercel-black?logo=vercel)](https://vercel.com)
+[![Netlify](https://img.shields.io/badge/Netlify-00C7B7?logo=netlify&logoColor=white)](https://www.netlify.com)
+[![React](https://img.shields.io/badge/React-18-61DAFB?logo=react&logoColor=black)](https://react.dev)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org)
+[![Vite](https://img.shields.io/badge/Vite-646CFF?logo=vite&logoColor=white)](https://vitejs.dev)
+
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 
 Currently, two official plugins are available:


### PR DESCRIPTION
## Summary
- add badges showing Vercel/Netlify readiness and key tools

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*