### PR TITLE
Fix bug modal click handling

### DIFF
--- a/src/components/BugCard.tsx
+++ b/src/components/BugCard.tsx
@@ -27,7 +27,10 @@ export const BugCard: React.FC<Props> = ({ bug, preview = false }) => {
         !bug.active && "opacity-40 grayscale",
         preview ? "w-[200px]" : "w-80"
       )}
-      onClick={() => bug.active && squashBug(bug.id)}
+      onClick={(e) => {
+        e.stopPropagation();
+        if (bug.active) squashBug(bug.id);
+      }}
       initial={{ opacity: 0, scale: 0.9 }}
       animate={{ opacity: 1, scale: 1 }}
       transition={{ duration: 0.3 }}

--- a/src/components/BugCrawler.tsx
+++ b/src/components/BugCrawler.tsx
@@ -163,10 +163,24 @@ const BugCrawler: React.FC<BugCrawlerProps> = ({
 
       {/* modal on click */}
       {showModal && isAlive && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/20">
-          <div className="relative">
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/20"
+          onClick={(e) => {
+            e.stopPropagation();
+            inspectBug("");
+          }}
+        >
+          <div
+            className="relative"
+            onClick={(e) => {
+              e.stopPropagation();
+            }}
+          >
             <button
-              onClick={() => inspectBug("")}
+              onClick={(e) => {
+                e.stopPropagation();
+                inspectBug("");
+              }}
               className="absolute -top-8 -right-8 size-8 rounded-full bg-white p-1"
             >
               ✕


### PR DESCRIPTION
## Summary
- prevent overlay clicks from squashing bugs by accident
- stop propagation when squashing via BugCard

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test`
