### PR TITLE
Refactor win95 styles

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import UserProfile from "./routes/UserProfile";
 import Dashboard from "./routes/Dashboard";
 import NewBug from "./routes/NewBug";
 import { Minus, Square, X as CloseIcon } from "lucide-react";
+import { raised, windowShadow } from "./utils/win95";
 
 function AppContent() {
 	const location = useLocation();
@@ -22,13 +23,9 @@ function AppContent() {
 				if (location.pathname.startsWith("/user/")) return "User Profile";
 				return "Bug Bounty";
 		}
-	};
+        };
 
-	/* 3-D border helpers */
-	const raised = "border-2 border-t-white border-l-white border-b-gray-500 border-r-gray-500";
-	const windowShadow = "shadow-[inset_-2px_-2px_0_0_rgba(0,0,0,0.55),inset_2px_2px_0_0_rgba(255,255,255,0.8)]";
-
-	return (
+       return (
 		<div className="min-h-screen bg-[#008080] p-4 font-['MS_Sans_Serif','Tahoma',sans-serif] flex flex-col">
 			<div className="mx-auto max-w-7xl w-full flex-grow flex">
 				{/* Single Win95 Window */}

--- a/src/routes/Bugs.tsx
+++ b/src/routes/Bugs.tsx
@@ -1,8 +1,6 @@
 import BugArea from "../components/BugArea";
 import { useBugStore } from "../store";
-
-/* 3-D border helper (for the bug card area) */
-const raised = "border-2 border-t-white border-l-white border-b-gray-500 border-r-gray-500";
+import { raised } from "../utils/win95";
 
 export default function Bugs() {
 	const bugs = useBugStore((s) => s.bugs);

--- a/src/routes/Dashboard.tsx
+++ b/src/routes/Dashboard.tsx
@@ -10,6 +10,7 @@ import { motion } from "framer-motion";
 import { useEffect, useState } from "react";
 import BugTrendsChart from "../components/BugTrendsChart";
 import { useNavigate } from "react-router-dom";
+import { raised as raisedBase, sunken as sunkenBase } from "../utils/win95";
 
 // Helper function to calculate total bounty
 const calculateTotalBounty = (bugs: Bug[]): number => bugs.reduce((total, bug) => total + bug.bounty, 0);
@@ -98,9 +99,9 @@ export default function Dashboard() {
 		return () => clearTimeout(timer);
 	}, [bugs, activeBugs, squashedBugs, activeBountyTotal, squashedBountyTotal]);
 
-	/* 3-D border helpers with enhanced styles */
-	const raised = "border-2 border-t-white border-l-white border-b-gray-500 border-r-gray-500 shadow-sm";
-	const sunken = "border-2 border-t-gray-500 border-l-gray-500 border-b-white border-r-white shadow-inner";
+        /* 3-D border helpers with enhanced styles */
+        const raised = `${raisedBase} shadow-sm`;
+        const sunken = `${sunkenBase} shadow-inner`;
 
 	return (
 		<motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.5 }}>

--- a/src/routes/NewBug.tsx
+++ b/src/routes/NewBug.tsx
@@ -10,6 +10,7 @@ import { useBugStore } from "../store";
 import { v4 as uuidv4 } from "uuid";
 import { motion } from "framer-motion";
 import { Bug } from "../types/bug";
+import { raised as raisedBase, sunken as sunkenBase } from "../utils/win95";
 
 export default function NewBug() {
 	const navigate = useNavigate();
@@ -46,9 +47,9 @@ export default function NewBug() {
                 navigate("/dashboard");
         };
 
-	/* 3-D border helpers with enhanced styles */
-	const raised = "border-2 border-t-white border-l-white border-b-gray-500 border-r-gray-500 shadow-sm";
-	const sunken = "border-2 border-t-gray-500 border-l-gray-500 border-b-white border-r-white shadow-inner";
+        /* 3-D border helpers with enhanced styles */
+        const raised = `${raisedBase} shadow-sm`;
+        const sunken = `${sunkenBase} shadow-inner`;
 
 	return (
 		<motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.5 }} className="max-w-2xl mx-auto">

--- a/src/routes/UserProfile.tsx
+++ b/src/routes/UserProfile.tsx
@@ -1,9 +1,6 @@
 import { useParams, Link } from "react-router-dom";
 import { useBugStore } from "../store";
-
-/* 3-D border helper */
-const raised =
-  "border-2 border-t-white border-l-white border-b-gray-500 border-r-gray-500";
+import { raised } from "../utils/win95";
 
 export default function UserProfile() {
   const { userId } = useParams<{ userId: string }>();

--- a/src/utils/win95.ts
+++ b/src/utils/win95.ts
@@ -1,0 +1,3 @@
+export const raised = "border-2 border-t-white border-l-white border-b-gray-500 border-r-gray-500";
+export const sunken = "border-2 border-t-gray-500 border-l-gray-500 border-b-white border-r-white";
+export const windowShadow = "shadow-[inset_-2px_-2px_0_0_rgba(0,0,0,0.55),inset_2px_2px_0_0_rgba(255,255,255,0.8)]";


### PR DESCRIPTION
## Summary
- centralize win95 border styles in `utils/win95.ts`
- use the new constants across components and routes

## Testing
- `npm test`