### PR TITLE
Fix inspect modal close bug

### DIFF
--- a/src/components/BugArea.tsx
+++ b/src/components/BugArea.tsx
@@ -68,7 +68,7 @@ const BugArea: React.FC<BugAreaProps> = ({ bugs }) => {
     // If a modal is open, squash that bug and close the modal.
     if (inspectedIdRef.current) {
       squashBug(inspectedIdRef.current);
-      inspectBug("");
+      inspectBug(null);
       return;
     }
 

--- a/src/components/BugCrawler.tsx
+++ b/src/components/BugCrawler.tsx
@@ -167,7 +167,7 @@ const BugCrawler: React.FC<BugCrawlerProps> = ({
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/20"
           onClick={(e) => {
             e.stopPropagation();
-            inspectBug("");
+            inspectBug(null);
           }}
         >
           <div
@@ -179,7 +179,7 @@ const BugCrawler: React.FC<BugCrawlerProps> = ({
             <button
               onClick={(e) => {
                 e.stopPropagation();
-                inspectBug("");
+                inspectBug(null);
               }}
               className="absolute -top-8 -right-8 size-8 rounded-full bg-white p-1"
             >

--- a/src/store.ts
+++ b/src/store.ts
@@ -9,7 +9,7 @@ interface State {
         users: User[];
         activeUserId: number;
         inspectedId: string | null;
-        inspectBug: (id: string) => void;
+        inspectBug: (id: string | null) => void;
         squashBug: (id: string) => void;
         addBug: (bug: Bug) => void;
 }


### PR DESCRIPTION
## Summary
- allow inspectBug to accept `null`
- clear inspectedId using `null`

## Testing
- `npx tsc --noEmit`
- `npm test`
- `npm run lint`
