### PR TITLE
Add per-page meta tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.eslintcache

--- a/index.html
+++ b/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/src/assets/hammer.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Bug Basher lets you squash bugs and earn bounties in a retro-inspired game."
+    />
     <title>Bug Basher</title>
     <script
       defer

--- a/src/components/Meta.tsx
+++ b/src/components/Meta.tsx
@@ -1,0 +1,23 @@
+import { useEffect } from 'react'
+
+interface MetaProps {
+  title: string
+  description: string
+}
+
+export default function Meta({ title, description }: MetaProps) {
+  useEffect(() => {
+    document.title = title
+    let meta = document.querySelector(
+      'meta[name="description"]'
+    ) as HTMLMetaElement | null
+    if (!meta) {
+      meta = document.createElement('meta')
+      meta.setAttribute('name', 'description')
+      document.head.appendChild(meta)
+    }
+    meta.setAttribute('content', description)
+  }, [title, description])
+
+  return null
+}

--- a/src/routes/Bugs.tsx
+++ b/src/routes/Bugs.tsx
@@ -1,22 +1,29 @@
 import BugArea from '../components/BugArea'
 import { useBugStore } from '../store'
 import { raised } from '../utils/win95'
+import Meta from '../components/Meta'
 
 export default function Bugs() {
   const bugs = useBugStore(s => s.bugs)
 
   return (
-    <div className="flex flex-col h-full">
-      <div
-        className={`bg-[#E0E0E0] ${raised} p-2 flex-grow relative`}
-        style={{ minHeight: '60vh' }}
-      >
-        <BugArea bugs={bugs} />
-      </div>
+    <>
+      <Meta
+        title="Bug Basher - Squash Bugs"
+        description="Play Bug Basher and earn bounties by squashing pesky bugs."
+      />
+      <div className="flex flex-col h-full">
+        <div
+          className={`bg-[#E0E0E0] ${raised} p-2 flex-grow relative`}
+          style={{ minHeight: '60vh' }}
+        >
+          <BugArea bugs={bugs} />
+        </div>
 
-      <p className="text-center text-sm text-gray-800 py-2">
-        Click to squash a bug&nbsp;&amp;&nbsp;earn its bounty 👆
-      </p>
-    </div>
+        <p className="text-center text-sm text-gray-800 py-2">
+          Click to squash a bug&nbsp;&amp;&nbsp;earn its bounty 👆
+        </p>
+      </div>
+    </>
   )
 }

--- a/src/routes/Dashboard.tsx
+++ b/src/routes/Dashboard.tsx
@@ -12,6 +12,7 @@ import { Bug } from '../types/bug'
 import { Badge } from '../components/ui/badge'
 import { Progress } from '../components/ui/progress'
 import { Button } from '../components/ui/button'
+import Meta from '../components/Meta'
 import {
   CalendarIcon,
   CheckCircleIcon,
@@ -166,6 +167,10 @@ export default function Dashboard() {
       animate={{ opacity: 1 }}
       transition={{ duration: 0.5 }}
     >
+      <Meta
+        title="Bug Dashboard - Stats and Progress"
+        description="Track bug statistics, bounties and progress on the Bug Basher dashboard."
+      />
       {/* Header with title and date */}
       <div className="mb-6 flex justify-between items-start">
         <motion.div

--- a/src/routes/Leaderboard.tsx
+++ b/src/routes/Leaderboard.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
 import { useBugStore } from '../store'
+import Meta from '../components/Meta'
 
 /** Map bounty → tier name */
 const levelFromBounty = (bounty: number): string => {
@@ -96,95 +97,102 @@ export default function Leaderboard() {
     sortKey === key ? (ascending ? '▲' : '▼') : ''
 
   return (
-    <div className="overflow-x-auto">
-      <table className="w-full text-sm select-none bg-[#E0E0E0]">
-        <thead>
-          <tr className="bg-[#000080] text-white">
-            <th
-              onClick={() => handleSort('rank')}
-              className="py-2 px-3 text-left font-semibold w-16 whitespace-nowrap cursor-pointer"
-            >
-              #<span className="ml-1">{sortArrow('rank')}</span>
-            </th>
-            <th
-              onClick={() => handleSort('name')}
-              className="py-2 px-3 text-left font-semibold cursor-pointer"
-            >
-              Hunter <span className="ml-1">{sortArrow('name')}</span>
-            </th>
-            <th
-              onClick={() => handleSort('bugs')}
-              className="py-2 px-3 text-right font-semibold w-24 cursor-pointer"
-            >
-              Bugs <span className="ml-1">{sortArrow('bugs')}</span>
-            </th>
-            <th
-              onClick={() => handleSort('bounty')}
-              className="py-2 px-3 text-right font-semibold w-28 cursor-pointer"
-            >
-              Bounty <span className="ml-1">{sortArrow('bounty')}</span>
-            </th>
-            <th
-              onClick={() => handleSort('efficiency')}
-              className="py-2 px-3 text-right font-semibold w-32 cursor-pointer"
-            >
-              Efficiency <span className="ml-1">{sortArrow('efficiency')}</span>
-            </th>
-            <th
-              onClick={() => handleSort('level')}
-              className="py-2 px-3 text-center font-semibold w-28 cursor-pointer"
-            >
-              Level <span className="ml-1">{sortArrow('level')}</span>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {sortedUsers.map((u, i) => {
-            const bugCount =
-              (Array.isArray(u.bugs) ? u.bugs.length : u.bugs) ?? 0
-            const bounty = u.bounty ?? 0
-            const efficiency =
-              bugCount > 0 ? (bounty / bugCount).toFixed(1) : '—'
-            const level = levelFromBounty(bounty)
-
-            return (
-              <tr
-                key={u.id}
-                className={`${
-                  i % 2 ? 'bg-[#D4D0C8]' : 'bg-[#E0E0E0]'
-                } hover:bg-[#C0C0C0]`}
+    <>
+      <Meta
+        title="Bug Bounty Leaderboard"
+        description="Check the rankings of top bug squashers and their bounties."
+      />
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm select-none bg-[#E0E0E0]">
+          <thead>
+            <tr className="bg-[#000080] text-white">
+              <th
+                onClick={() => handleSort('rank')}
+                className="py-2 px-3 text-left font-semibold w-16 whitespace-nowrap cursor-pointer"
               >
-                <td className="py-1 px-3 font-bold">{i + 1}</td>
-                <td className="py-1 px-3 flex items-center gap-2">
-                  {u.avatar && (
-                    <img
-                      src={u.avatar}
-                      alt={`${u.name} avatar`}
-                      className="w-6 h-6 border border-gray-700"
-                    />
-                  )}
-                  <Link
-                    to={`/user/${u.id}`}
-                    className="text-indigo-600 hover:underline"
-                  >
-                    {u.name}
-                  </Link>
-                </td>
-                <td className="py-1 px-3 text-right tabular-nums">
-                  {bugCount}
-                </td>
-                <td className="py-1 px-3 text-right tabular-nums">
-                  {bounty.toLocaleString()}
-                </td>
-                <td className="py-1 px-3 text-right tabular-nums">
-                  {efficiency}
-                </td>
-                <td className="py-1 px-3 text-center">{level}</td>
-              </tr>
-            )
-          })}
-        </tbody>
-      </table>
-    </div>
+                #<span className="ml-1">{sortArrow('rank')}</span>
+              </th>
+              <th
+                onClick={() => handleSort('name')}
+                className="py-2 px-3 text-left font-semibold cursor-pointer"
+              >
+                Hunter <span className="ml-1">{sortArrow('name')}</span>
+              </th>
+              <th
+                onClick={() => handleSort('bugs')}
+                className="py-2 px-3 text-right font-semibold w-24 cursor-pointer"
+              >
+                Bugs <span className="ml-1">{sortArrow('bugs')}</span>
+              </th>
+              <th
+                onClick={() => handleSort('bounty')}
+                className="py-2 px-3 text-right font-semibold w-28 cursor-pointer"
+              >
+                Bounty <span className="ml-1">{sortArrow('bounty')}</span>
+              </th>
+              <th
+                onClick={() => handleSort('efficiency')}
+                className="py-2 px-3 text-right font-semibold w-32 cursor-pointer"
+              >
+                Efficiency{' '}
+                <span className="ml-1">{sortArrow('efficiency')}</span>
+              </th>
+              <th
+                onClick={() => handleSort('level')}
+                className="py-2 px-3 text-center font-semibold w-28 cursor-pointer"
+              >
+                Level <span className="ml-1">{sortArrow('level')}</span>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {sortedUsers.map((u, i) => {
+              const bugCount =
+                (Array.isArray(u.bugs) ? u.bugs.length : u.bugs) ?? 0
+              const bounty = u.bounty ?? 0
+              const efficiency =
+                bugCount > 0 ? (bounty / bugCount).toFixed(1) : '—'
+              const level = levelFromBounty(bounty)
+
+              return (
+                <tr
+                  key={u.id}
+                  className={`${
+                    i % 2 ? 'bg-[#D4D0C8]' : 'bg-[#E0E0E0]'
+                  } hover:bg-[#C0C0C0]`}
+                >
+                  <td className="py-1 px-3 font-bold">{i + 1}</td>
+                  <td className="py-1 px-3 flex items-center gap-2">
+                    {u.avatar && (
+                      <img
+                        src={u.avatar}
+                        alt={`${u.name} avatar`}
+                        className="w-6 h-6 border border-gray-700"
+                      />
+                    )}
+                    <Link
+                      to={`/user/${u.id}`}
+                      className="text-indigo-600 hover:underline"
+                    >
+                      {u.name}
+                    </Link>
+                  </td>
+                  <td className="py-1 px-3 text-right tabular-nums">
+                    {bugCount}
+                  </td>
+                  <td className="py-1 px-3 text-right tabular-nums">
+                    {bounty.toLocaleString()}
+                  </td>
+                  <td className="py-1 px-3 text-right tabular-nums">
+                    {efficiency}
+                  </td>
+                  <td className="py-1 px-3 text-center">{level}</td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+    </>
   )
 }

--- a/src/routes/NewBug.tsx
+++ b/src/routes/NewBug.tsx
@@ -23,6 +23,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { motion } from 'framer-motion'
 import { Bug } from '../types/bug'
 import { raised as raisedBase, sunken as sunkenBase } from '../utils/win95'
+import Meta from '../components/Meta'
 
 export default function NewBug() {
   const navigate = useNavigate()
@@ -64,97 +65,103 @@ export default function NewBug() {
   const sunken = `${sunkenBase} shadow-inner`
 
   return (
-    <motion.div
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      transition={{ duration: 0.5 }}
-      className="max-w-2xl mx-auto"
-    >
-      <Card className={`bg-[#E0E0E0] ${raised}`}>
-        <CardHeader>
-          <CardTitle className="text-2xl font-bold">File a New Bug</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          {error && (
-            <div className={`${sunken} bg-red-100 text-red-800 p-2 text-sm`}>
-              {error}
-            </div>
-          )}
+    <>
+      <Meta
+        title="File a New Bug"
+        description="Report a new bug and earn bounties in Bug Basher."
+      />
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.5 }}
+        className="max-w-2xl mx-auto"
+      >
+        <Card className={`bg-[#E0E0E0] ${raised}`}>
+          <CardHeader>
+            <CardTitle className="text-2xl font-bold">File a New Bug</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {error && (
+              <div className={`${sunken} bg-red-100 text-red-800 p-2 text-sm`}>
+                {error}
+              </div>
+            )}
 
-          <div className="space-y-1">
-            <Label htmlFor="title">Bug Title</Label>
-            <Input
-              id="title"
-              value={title}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                setTitle(e.target.value)
-              }
-              className={`bg-white ${sunken}`}
-            />
-          </div>
-
-          <div className="space-y-1">
-            <Label htmlFor="description">Description</Label>
-            <Textarea
-              id="description"
-              value={description}
-              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
-                setDescription(e.target.value)
-              }
-              className={`bg-white ${sunken} min-h-[100px]`}
-            />
-          </div>
-
-          <div className="grid grid-cols-2 gap-4">
             <div className="space-y-1">
-              <Label htmlFor="bounty">Bounty Amount ($)</Label>
+              <Label htmlFor="title">Bug Title</Label>
               <Input
-                id="bounty"
-                type="number"
-                min={10}
-                value={bounty}
+                id="title"
+                value={title}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                  setBounty(Number(e.target.value))
+                  setTitle(e.target.value)
                 }
                 className={`bg-white ${sunken}`}
               />
             </div>
 
             <div className="space-y-1">
-              <Label htmlFor="priority">Priority</Label>
-              <Select
-                value={priority}
-                onValueChange={(value: 'high' | 'medium' | 'low') =>
-                  setPriority(value)
+              <Label htmlFor="description">Description</Label>
+              <Textarea
+                id="description"
+                value={description}
+                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                  setDescription(e.target.value)
                 }
-              >
-                <SelectTrigger className={`${raised} bg-[#C0C0C0]`}>
-                  <SelectValue placeholder="Select priority" />
-                </SelectTrigger>
-                <SelectContent className={`${raised} bg-[#C0C0C0] w-full`}>
-                  <SelectItem value="high">high</SelectItem>
-                  <SelectItem value="medium">medium</SelectItem>
-                  <SelectItem value="low">low</SelectItem>
-                </SelectContent>
-              </Select>
+                className={`bg-white ${sunken} min-h-[100px]`}
+              />
             </div>
-          </div>
-        </CardContent>
-        <CardFooter className="flex justify-between">
-          <Button
-            className={`${raised} bg-[#C0C0C0] hover:bg-[#A0A0A0] text-black`}
-            onClick={() => navigate('/dashboard')}
-          >
-            Cancel
-          </Button>
-          <Button
-            className={`${raised} bg-[#008080] hover:bg-[#006666] text-white`}
-            onClick={createBug}
-          >
-            Submit Bug
-          </Button>
-        </CardFooter>
-      </Card>
-    </motion.div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-1">
+                <Label htmlFor="bounty">Bounty Amount ($)</Label>
+                <Input
+                  id="bounty"
+                  type="number"
+                  min={10}
+                  value={bounty}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    setBounty(Number(e.target.value))
+                  }
+                  className={`bg-white ${sunken}`}
+                />
+              </div>
+
+              <div className="space-y-1">
+                <Label htmlFor="priority">Priority</Label>
+                <Select
+                  value={priority}
+                  onValueChange={(value: 'high' | 'medium' | 'low') =>
+                    setPriority(value)
+                  }
+                >
+                  <SelectTrigger className={`${raised} bg-[#C0C0C0]`}>
+                    <SelectValue placeholder="Select priority" />
+                  </SelectTrigger>
+                  <SelectContent className={`${raised} bg-[#C0C0C0] w-full`}>
+                    <SelectItem value="high">high</SelectItem>
+                    <SelectItem value="medium">medium</SelectItem>
+                    <SelectItem value="low">low</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+          </CardContent>
+          <CardFooter className="flex justify-between">
+            <Button
+              className={`${raised} bg-[#C0C0C0] hover:bg-[#A0A0A0] text-black`}
+              onClick={() => navigate('/dashboard')}
+            >
+              Cancel
+            </Button>
+            <Button
+              className={`${raised} bg-[#008080] hover:bg-[#006666] text-white`}
+              onClick={createBug}
+            >
+              Submit Bug
+            </Button>
+          </CardFooter>
+        </Card>
+      </motion.div>
+    </>
   )
 }

--- a/src/routes/UserProfile.tsx
+++ b/src/routes/UserProfile.tsx
@@ -1,6 +1,7 @@
 import { useParams, Link } from 'react-router-dom'
 import { useBugStore } from '../store'
 import { raised } from '../utils/win95'
+import Meta from '../components/Meta'
 
 export default function UserProfile() {
   const { userId } = useParams<{ userId: string }>()
@@ -11,14 +12,20 @@ export default function UserProfile() {
 
   if (!user) {
     return (
-      <div className="text-center space-y-4">
-        <Link
-          to="/bounty-leaderboard"
-          className="text-indigo-600 hover:underline"
-        >
-          Back to Leaderboard
-        </Link>
-      </div>
+      <>
+        <Meta
+          title="User Not Found - Bug Bounty"
+          description="The requested user profile could not be located."
+        />
+        <div className="text-center space-y-4">
+          <Link
+            to="/bounty-leaderboard"
+            className="text-indigo-600 hover:underline"
+          >
+            Back to Leaderboard
+          </Link>
+        </div>
+      </>
     )
   }
 
@@ -29,71 +36,77 @@ export default function UserProfile() {
   const totalBounty = squashedBugs.reduce((sum, bug) => sum + bug.bounty, 0)
 
   return (
-    <div className="mx-auto max-w-md space-y-6">
-      <div className={`bg-[#E0E0E0] ${raised}`}>
-        <div className="p-6 space-y-6">
-          <div className="text-center">
-            <h2 className="text-2xl font-bold">{user.name}</h2>
-            <p className="mt-1 text-lg font-mono text-emerald-700">
-              {(user.score ?? 0).toLocaleString()} points
-            </p>
-          </div>
-
-          <div className="space-y-2">
-            <div className="flex justify-between border-b pb-2">
-              <span>Total Bugs Squashed:</span>
-              <span className="font-medium">
-                {user.bugsSquashed?.length ?? 0}
-              </span>
-            </div>
-
-            <div className="flex justify-between border-b pb-2">
-              <span>Total Bounty Collected:</span>
-              <span className="font-medium">
-                {totalBounty.toLocaleString()}
-              </span>
-            </div>
-
-            <div className="flex justify-between border-b pb-2">
-              <span>Rank:</span>
-              <span className="font-medium">
-                #{users.findIndex(u => u.id === id) + 1}
-              </span>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {squashedBugs.length > 0 && (
+    <>
+      <Meta
+        title={`Bug Bounty Profile - ${user.name}`}
+        description={`Stats and achievements for ${user.name} in Bug Basher.`}
+      />
+      <div className="mx-auto max-w-md space-y-6">
         <div className={`bg-[#E0E0E0] ${raised}`}>
-          <div className="p-6 space-y-2">
-            <h3 className="mb-3 text-xl font-semibold">Bugs Squashed</h3>
-            {squashedBugs.map(bug => (
-              <div
-                key={bug.id}
-                className="rounded-lg border bg-white p-3 shadow-sm"
-              >
-                <div className="font-medium">{bug.title}</div>
-                <div className="mt-1 text-sm text-gray-600">
-                  {bug.description}
-                </div>
-                <div className="mt-2 text-right font-mono text-emerald-700">
-                  +{bug.bounty.toLocaleString()}
-                </div>
+          <div className="p-6 space-y-6">
+            <div className="text-center">
+              <h2 className="text-2xl font-bold">{user.name}</h2>
+              <p className="mt-1 text-lg font-mono text-emerald-700">
+                {(user.score ?? 0).toLocaleString()} points
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <div className="flex justify-between border-b pb-2">
+                <span>Total Bugs Squashed:</span>
+                <span className="font-medium">
+                  {user.bugsSquashed?.length ?? 0}
+                </span>
               </div>
-            ))}
+
+              <div className="flex justify-between border-b pb-2">
+                <span>Total Bounty Collected:</span>
+                <span className="font-medium">
+                  {totalBounty.toLocaleString()}
+                </span>
+              </div>
+
+              <div className="flex justify-between border-b pb-2">
+                <span>Rank:</span>
+                <span className="font-medium">
+                  #{users.findIndex(u => u.id === id) + 1}
+                </span>
+              </div>
+            </div>
           </div>
         </div>
-      )}
 
-      <div className="text-center">
-        <Link
-          to="/bounty-leaderboard"
-          className="text-indigo-600 hover:underline"
-        >
-          Back to Leaderboard
-        </Link>
+        {squashedBugs.length > 0 && (
+          <div className={`bg-[#E0E0E0] ${raised}`}>
+            <div className="p-6 space-y-2">
+              <h3 className="mb-3 text-xl font-semibold">Bugs Squashed</h3>
+              {squashedBugs.map(bug => (
+                <div
+                  key={bug.id}
+                  className="rounded-lg border bg-white p-3 shadow-sm"
+                >
+                  <div className="font-medium">{bug.title}</div>
+                  <div className="mt-1 text-sm text-gray-600">
+                    {bug.description}
+                  </div>
+                  <div className="mt-2 text-right font-mono text-emerald-700">
+                    +{bug.bounty.toLocaleString()}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <div className="text-center">
+          <Link
+            to="/bounty-leaderboard"
+            className="text-indigo-600 hover:underline"
+          >
+            Back to Leaderboard
+          </Link>
+        </div>
       </div>
-    </div>
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- create a small `Meta` component to update `<title>` and the description meta tag
- include the new `Meta` component in all routes to give each page unique metadata
- add a default description meta tag in `index.html`
- fix missing closing tag in the dashboard page
- ignore `.eslintcache`

## Testing
- `npm run lint`
- `npm test`
