### PR TITLE
Sort active bugs by bounty

### DIFF
--- a/src/routes/Dashboard.tsx
+++ b/src/routes/Dashboard.tsx
@@ -118,7 +118,10 @@ const ActivityTimeline = ({ bugs }: { bugs: Bug[] }) => {
 
 export default function Dashboard() {
   const bugs = useBugStore(s => s.bugs)
-  const activeBugs = bugs.filter(bug => bug.active)
+  // Sort active bugs by bounty in descending order for display
+  const activeBugs = bugs
+    .filter(bug => bug.active)
+    .sort((a, b) => b.bounty - a.bounty)
   const squashedBugs = bugs.filter(bug => !bug.active)
   const [stats, setStats] = useState({
     active: 0,


### PR DESCRIPTION
## Summary
- sort active bugs in descending bounty order on Dashboard page

## Testing
- `npm test`
- `npm run lint`
