### PR TITLE
Fix stat-card decoration position

### DIFF
--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -8,7 +8,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      'rounded-lg border bg-card text-card-foreground shadow-sm',
+      'relative rounded-lg border bg-card text-card-foreground shadow-sm',
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary
- ensure Card component uses `position: relative`

The top stat cards on the dashboard contained decorative circles absolutely positioned. Because the Card component wasn't positioned, those circles were placed relative to the viewport, appearing near the "File a Bug" button.

## Testing
- `npm test` *(fails: Cannot find package 'clsx')*