### PR TITLE
Add naming conventions docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,19 @@ src/
 └── vite-env.d.ts    # Types for things that don't need types
 ```
 
+### Naming Conventions
+
+See [docs/NAMING_CONVENTIONS.md](docs/NAMING_CONVENTIONS.md) for the complete guide.
+
+- **Folders**: lower-case names, hyphenated when needed.
+- **Component files**: `PascalCase.tsx`.
+- **Utilities**: lower-case with optional hyphens, e.g., `utils.ts`.
+- **Test files**: same base name plus `.test.ts`.
+- **Components**: export default components with names matching their file.
+- **Variables/functions**: camelCase.
+- **Constants**: `UPPER_SNAKE_CASE`.
+- **Types/interfaces**: PascalCase.
+
 ### 🎪 The Comedy Special Features
 
 **🐛 Bug Component Showcase:**

--- a/docs/NAMING_CONVENTIONS.md
+++ b/docs/NAMING_CONVENTIONS.md
@@ -1,0 +1,19 @@
+# Naming Conventions
+
+This project follows a few simple rules to keep file and variable names predictable.
+
+## Folders
+
+- Lower-case names, hyphenated when a folder name contains multiple words.
+
+## Files
+
+- React components use `PascalCase.tsx` and export a default component with the same name.
+- Non-component utilities and modules use lower-case names and may include hyphens, e.g. `utils.ts`, `badge-variants.ts`.
+- Test files mirror the module they cover and use the `.test.ts` extension.
+
+## Code
+
+- Variables and functions are written in `camelCase`.
+- Constants that represent configuration values are written in `UPPER_SNAKE_CASE`.
+- Types and interfaces use `PascalCase`.

--- a/src/components/Meta.tsx
+++ b/src/components/Meta.tsx
@@ -4,7 +4,7 @@ interface MetaProps {
   title: string
   description: string
   image?: string
-  structuredData?: Record<string, any>
+  structuredData?: Record<string, unknown>
 }
 
 export default function Meta({


### PR DESCRIPTION
## Summary
- document project naming conventions in README and docs
- fix ESLint error in `Meta` component

## Testing
- `npm test`
- `npm run lint`
