### PR TITLE
Add store timer tests

### DIFF
--- a/src/mock/bugs.ts
+++ b/src/mock/bugs.ts
@@ -1,4 +1,4 @@
-import { Bug } from '../types/bug'
+import type { Bug } from '../types/bug.ts'
 
 // Helper to create dates in the past (days ago)
 const daysAgo = (days: number): string => {

--- a/src/mock/users.ts
+++ b/src/mock/users.ts
@@ -8,7 +8,7 @@ import antAvatar from '../assets/ant.png'
 import mothAvatar from '../assets/moth.png'
 import cockroachAvatar from '../assets/cockroach.png'
 import caterpillarAvatar from '../assets/caterpillar.png'
-import { User } from '../types/user'
+import type { User } from '../types/user.ts'
 
 /**
  * Demo leaderboard data – feel free to tweak!

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1,0 +1,66 @@
+import { test, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import { useBugStore } from './store.ts'
+import { bugs as mockBugs } from './mock/bugs.ts'
+import { users as mockUsers } from './mock/users.ts'
+
+const resetStore = () => {
+  useBugStore.getState().stopAutomaticSystems()
+  useBugStore.setState({
+    bugs: structuredClone(mockBugs),
+    users: structuredClone(mockUsers).sort((a, b) => b.bounty - a.bounty),
+    activeUserId: 1,
+    inspectedId: null,
+  })
+}
+
+const timers = mock.timers
+
+// Test that squashBug updates score and bug cleanup works
+
+test('squashBug updates score and removes bug after cleanup', () => {
+  timers.enable()
+  resetStore()
+
+  useBugStore.getState().startAutomaticSystems()
+
+  const id = mockBugs[0].id
+  const bounty = mockBugs[0].bounty
+
+  useBugStore.getState().squashBug(id)
+
+  let bug = useBugStore.getState().bugs.find(b => b.id === id)
+  assert.ok(bug)
+  assert.strictEqual(bug!.active, false)
+
+  const user = useBugStore.getState().users.find(u => u.id === 1)
+  assert.ok(user)
+  assert.strictEqual(user!.score, bounty)
+  assert.ok(user!.bugsSquashed?.includes(id))
+
+  timers.tick(12000)
+
+  bug = useBugStore.getState().bugs.find(b => b.id === id)
+  assert.strictEqual(bug, undefined)
+
+  useBugStore.getState().stopAutomaticSystems()
+  timers.reset()
+})
+
+// Test that respawn timer adds bugs when below minimum
+
+test('respawn timer adds bugs when below minimum', () => {
+  timers.enable()
+  resetStore()
+
+  useBugStore.setState({ bugs: [] })
+  useBugStore.getState().startAutomaticSystems()
+
+  timers.tick(3000)
+
+  const activeBugs = useBugStore.getState().bugs.filter(b => b.active)
+  assert.ok(activeBugs.length >= 8)
+
+  useBugStore.getState().stopAutomaticSystems()
+  timers.reset()
+})

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,8 +1,8 @@
 import { create } from 'zustand'
-import { bugs as mockBugs } from './mock/bugs'
-import { users as mockUsers } from './mock/users'
-import { Bug } from './types/bug'
-import type { User } from './types/user'
+import { bugs as mockBugs } from './mock/bugs.ts'
+import { users as mockUsers } from './mock/users.ts'
+import type { Bug } from './types/bug.ts'
+import type { User } from './types/user.ts'
 
 interface State {
   bugs: Bug[]


### PR DESCRIPTION
## Summary
- fix missing file extensions in store imports
- create store.test.ts for timer-based logic

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
