### PR TITLE
Improve 404 page humor

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ const Leaderboard = lazy(() => import('./routes/Leaderboard'))
 const UserProfile = lazy(() => import('./routes/UserProfile'))
 const Dashboard = lazy(() => import('./routes/Dashboard'))
 const NewBug = lazy(() => import('./routes/NewBug'))
+const NotFound = lazy(() => import('./routes/NotFound'))
 import { Minus, Square, X as CloseIcon } from 'lucide-react'
 import { raised, windowShadow } from './utils/win95'
 
@@ -36,7 +37,7 @@ function AppContent() {
         return 'File a Bug'
       default:
         if (location.pathname.startsWith('/user/')) return 'User Profile'
-        return 'Bug Bounty'
+        return 'Page Not Found'
     }
   }
 
@@ -104,6 +105,7 @@ function AppContent() {
                   <Route path="/bounty-leaderboard" element={<Leaderboard />} />
                   <Route path="/user/:userId" element={<UserProfile />} />
                   <Route path="/bug/new" element={<NewBug />} />
+                  <Route path="*" element={<NotFound />} />
                 </Routes>
               </Suspense>
             </div>

--- a/src/routes/NotFound.tsx
+++ b/src/routes/NotFound.tsx
@@ -1,0 +1,27 @@
+import { Link } from 'react-router-dom'
+import Meta from '../components/Meta'
+
+export default function NotFound() {
+  return (
+    <>
+      <Meta
+        title="Page Not Found - Bug Bounty"
+        description="This route is more elusive than a bug-free codebase."
+      />
+      <div className="text-center space-y-4">
+        <h1 className="text-2xl font-bold">404 - Page Not Found</h1>
+        <p className="text-lg">
+          Well, this is embarrassing. You found the page even we can&apos;t
+          find.
+        </p>
+        <p>
+          Either it never existed or a hungry bug devoured it in a midnight
+          snack.
+        </p>
+        <Link to="/" className="text-indigo-600 hover:underline">
+          Back to the bug hunt
+        </Link>
+      </div>
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- rewrite the `NotFound` page with playful text

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
