### PR TITLE
Add coverage reporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Test Coverage
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests with coverage
+        run: npm run coverage
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: coverage.lcov

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ dist-ssr
 *.sln
 *.sw?
 .eslintcache
+coverage.lcov

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint:ci": "eslint . --max-warnings=0",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "test": "node --experimental-transform-types --loader ./png-loader.js --test"
+    "test": "node --experimental-transform-types --loader ./png-loader.js --test",
+    "coverage": "node --experimental-test-coverage --experimental-transform-types --loader ./png-loader.js --test --test-reporter=spec --test-reporter=lcov --test-reporter-destination=stdout --test-reporter-destination=coverage.lcov --test-coverage-exclude=\"node_modules/**\" --test-coverage-exclude=\"**/*.png\""
   },
   "dependencies": {
     "@radix-ui/react-navigation-menu": "^1.2.10",


### PR DESCRIPTION
## Summary
- collect coverage with a new npm script
- ignore generated coverage files
- run coverage in CI and upload artifact

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run coverage`