### PR TITLE
Add test coverage workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Test & Coverage
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests with coverage
+        run: npm run test:coverage | tee coverage.txt
+      - name: Display coverage summary
+        run: cat coverage.txt >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.txt

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ npm run build    # Create production build (good luck)
 npm run preview  # Preview build (spoiler: it's broken)
 npm run lint     # Find 47 linting errors you'll ignore
 npm test         # Run the single test that actually works
+npm run test:coverage # See how little of the code actually runs
 npm run format   # Rearrange deck chairs on the Titanic
 ```
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint:ci": "eslint . --max-warnings=0",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "test": "node --experimental-transform-types --loader ./png-loader.js --test"
+    "test": "node --experimental-transform-types --loader ./png-loader.js --test",
+    "test:coverage": "node --experimental-transform-types --loader ./png-loader.js --test --experimental-test-coverage --test-coverage-exclude=\"**/*.png\""
   },
   "dependencies": {
     "@radix-ui/react-navigation-menu": "^1.2.10",


### PR DESCRIPTION
## Summary
- add npm script for collecting coverage
- run tests with coverage in a new GitHub Actions workflow
- show coverage summary in the workflow output
- mention `test:coverage` script in README

## Testing
- `npm run format`
- `npm run lint`
- `npm test`