### PR TITLE
Add Quantum Bug Apocalypse mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ const NewBug = lazy(() => import('./routes/NewBug'))
 const NotFound = lazy(() => import('./routes/NotFound'))
 import { Minus, Square, X as CloseIcon } from 'lucide-react'
 import { raised, windowShadow } from './utils/win95'
+import QuantumOverlay from './components/QuantumOverlay'
 
 function AppContent() {
   const location = useLocation()
@@ -43,6 +44,7 @@ function AppContent() {
 
   return (
     <div className="min-h-screen bg-[#008080] p-4 font-['MS_Sans_Serif','Tahoma',sans-serif] flex flex-col">
+      <QuantumOverlay />
       <div className="mx-auto max-w-7xl w-full flex-grow flex">
         {/* Single Win95 Window */}
         <div

--- a/src/components/QuantumOverlay.tsx
+++ b/src/components/QuantumOverlay.tsx
@@ -1,0 +1,19 @@
+import { motion } from 'framer-motion'
+import { useBugStore } from '../store'
+
+const QuantumOverlay: React.FC = () => {
+  const quantumMode = useBugStore(s => s.quantumMode)
+  if (!quantumMode) return null
+  return (
+    <motion.div
+      className="fixed inset-0 pointer-events-none bg-purple-800 mix-blend-screen"
+      initial={{ opacity: 0 }}
+      animate={{
+        opacity: [0, 0.8, 0],
+        transition: { repeat: Infinity, duration: 0.3 },
+      }}
+    />
+  )
+}
+
+export default QuantumOverlay

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,25 +1,32 @@
 import * as React from 'react'
 import * as ProgressPrimitive from '@radix-ui/react-progress'
 import { cn } from '../../lib/utils'
+import { useBugStore } from '../../store'
 
 const Progress = React.forwardRef<
   React.ElementRef<typeof ProgressPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
->(({ className, value, ...props }, ref) => (
-  <ProgressPrimitive.Root
-    ref={ref}
-    className={cn(
-      'relative h-4 w-full overflow-hidden rounded-full bg-secondary',
-      className
-    )}
-    {...props}
-  >
-    <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-primary transition-all"
-      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
-    />
-  </ProgressPrimitive.Root>
-))
+>(({ className, value, ...props }, ref) => {
+  const quantumMode = useBugStore(s => s.quantumMode)
+  const transform = quantumMode
+    ? `translateX(${100 - (value || 0)}%)`
+    : `translateX(-${100 - (value || 0)}%)`
+  return (
+    <ProgressPrimitive.Root
+      ref={ref}
+      className={cn(
+        'relative h-4 w-full overflow-hidden rounded-full bg-secondary',
+        className
+      )}
+      {...props}
+    >
+      <ProgressPrimitive.Indicator
+        className="h-full w-full flex-1 bg-primary transition-all"
+        style={{ transform }}
+      />
+    </ProgressPrimitive.Root>
+  )
+})
 Progress.displayName = ProgressPrimitive.Root.displayName
 
 export { Progress }

--- a/src/mock/users.ts
+++ b/src/mock/users.ts
@@ -23,6 +23,7 @@ export const users: User[] = [
     bounty: 5400,
     score: 0,
     bugsSquashed: [],
+    badges: [],
   },
   {
     id: 2,
@@ -32,6 +33,7 @@ export const users: User[] = [
     bounty: 4950,
     score: 0,
     bugsSquashed: [],
+    badges: [],
   },
   {
     id: 3,
@@ -41,6 +43,7 @@ export const users: User[] = [
     bounty: 4100,
     score: 0,
     bugsSquashed: [],
+    badges: [],
   },
   {
     id: 4,
@@ -50,6 +53,7 @@ export const users: User[] = [
     bounty: 3600,
     score: 0,
     bugsSquashed: [],
+    badges: [],
   },
   {
     id: 5,
@@ -59,6 +63,7 @@ export const users: User[] = [
     bounty: 3200,
     score: 0,
     bugsSquashed: [],
+    badges: [],
   },
   {
     id: 6,
@@ -68,6 +73,7 @@ export const users: User[] = [
     bounty: 2800,
     score: 0,
     bugsSquashed: [],
+    badges: [],
   },
   {
     id: 7,
@@ -77,6 +83,7 @@ export const users: User[] = [
     bounty: 2200,
     score: 0,
     bugsSquashed: [],
+    badges: [],
   },
   {
     id: 8,
@@ -86,6 +93,7 @@ export const users: User[] = [
     bounty: 2000,
     score: 0,
     bugsSquashed: [],
+    badges: [],
   },
   {
     id: 9,
@@ -95,6 +103,7 @@ export const users: User[] = [
     bounty: 1600,
     score: 0,
     bugsSquashed: [],
+    badges: [],
   },
   {
     id: 10,
@@ -104,5 +113,6 @@ export const users: User[] = [
     bounty: 1200,
     score: 0,
     bugsSquashed: [],
+    badges: [],
   },
 ]

--- a/src/routes/Bugs.tsx
+++ b/src/routes/Bugs.tsx
@@ -1,10 +1,13 @@
 import BugArea from '../components/BugArea'
 import { useBugStore } from '../store'
 import { raised } from '../utils/win95'
+import { Button } from '../components/ui/button'
 import Meta from '../components/Meta'
 
 export default function Bugs() {
   const bugs = useBugStore(s => s.bugs)
+  const triggerQuantumApocalypse = useBugStore(s => s.triggerQuantumApocalypse)
+  const quantumMode = useBugStore(s => s.quantumMode)
 
   return (
     <>
@@ -28,6 +31,16 @@ export default function Bugs() {
         <p className="text-center text-sm text-gray-800 py-2">
           Click to squash a bug&nbsp;&amp;&nbsp;earn its bounty 👆
         </p>
+        <div className="text-center">
+          <Button
+            variant="default"
+            onClick={triggerQuantumApocalypse}
+            disabled={quantumMode}
+            className="mt-2 bg-purple-600 text-white hover:bg-purple-700"
+          >
+            {quantumMode ? 'Quantum Storm!' : 'Start Quantum Apocalypse'}
+          </Button>
+        </div>
       </div>
     </>
   )

--- a/src/routes/Leaderboard.tsx
+++ b/src/routes/Leaderboard.tsx
@@ -23,6 +23,7 @@ type SortKey = 'rank' | 'name' | 'bugs' | 'bounty' | 'efficiency' | 'level'
 
 export default function Leaderboard() {
   const users = useBugStore(s => s.users)
+  const quantumMode = useBugStore(s => s.quantumMode)
 
   /** Local sort state */
   const [sortKey, setSortKey] = React.useState<SortKey>('bounty')
@@ -42,6 +43,13 @@ export default function Leaderboard() {
   /** Users sorted according to selected column */
   const sortedUsers = React.useMemo(() => {
     const list = [...users]
+    if (quantumMode) {
+      for (let i = list.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1))
+        ;[list[i], list[j]] = [list[j], list[i]]
+      }
+      return list
+    }
 
     list.sort((a, b) => {
       const bugCountA =
@@ -90,7 +98,7 @@ export default function Leaderboard() {
     })
 
     return list
-  }, [users, sortKey, ascending])
+  }, [users, sortKey, ascending, quantumMode])
 
   /** Helper to render sort arrows */
   const sortArrow = (key: SortKey) =>
@@ -195,6 +203,9 @@ export default function Leaderboard() {
                     >
                       {u.name}
                     </Link>
+                    {u.badges?.includes('Quantum Survivor') && (
+                      <span title="Quantum Survivor">🌀</span>
+                    )}
                   </td>
                   <td className="py-1 px-3 text-right tabular-nums">
                     {bugCount}

--- a/src/store.ts
+++ b/src/store.ts
@@ -15,6 +15,8 @@ interface State {
   removeBug: (id: string) => void
   startAutomaticSystems: () => void
   stopAutomaticSystems: () => void
+  quantumMode: boolean
+  triggerQuantumApocalypse: () => void
 }
 
 // Configuration for automatic systems
@@ -71,12 +73,14 @@ const BUG_TEMPLATES = [
 
 let cleanupTimer: ReturnType<typeof setInterval> | null = null
 let respawnTimer: ReturnType<typeof setInterval> | null = null
+let apocalypseTimer: ReturnType<typeof setTimeout> | null = null
 
 export const useBugStore = create<State>((set, get) => ({
   bugs: mockBugs,
   users: mockUsers.sort((a, b) => b.bounty - a.bounty),
   activeUserId: 1, // assume first user is the current hacker
   inspectedId: null,
+  quantumMode: false,
   addBug: bug => set(state => ({ bugs: [...state.bugs, bug] })),
   inspectBug: id => set({ inspectedId: id }),
   removeBug: id =>
@@ -115,6 +119,41 @@ export const useBugStore = create<State>((set, get) => ({
 
       return { bugs, users, inspectedId: null }
     }),
+  triggerQuantumApocalypse: () => {
+    if (get().quantumMode || apocalypseTimer) return
+    set({ quantumMode: true })
+    for (let i = 0; i < 30; i++) {
+      const template =
+        BUG_TEMPLATES[Math.floor(Math.random() * BUG_TEMPLATES.length)]
+      const priorities: ('high' | 'medium' | 'low')[] = [
+        'high',
+        'medium',
+        'low',
+      ]
+      const priority = priorities[Math.floor(Math.random() * priorities.length)]
+      const newBug: Bug = {
+        id: `quantum-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+        title: template.title,
+        description: template.description,
+        bounty: Math.floor(Math.random() * 100) + 50,
+        active: true,
+        priority,
+        createdAt: new Date().toISOString(),
+      }
+      get().addBug(newBug)
+    }
+    apocalypseTimer = setTimeout(() => {
+      set(state => ({
+        quantumMode: false,
+        users: state.users.map(u =>
+          u.id === state.activeUserId
+            ? { ...u, badges: [...(u.badges || []), 'Quantum Survivor'] }
+            : u
+        ),
+      }))
+      apocalypseTimer = null
+    }, 8000)
+  },
   startAutomaticSystems: () => {
     // Start cleanup timer for squashed bugs
     if (!cleanupTimer) {

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -8,4 +8,5 @@ export interface User {
   bounty: number
   score?: number
   bugsSquashed?: string[]
+  badges?: string[]
 }


### PR DESCRIPTION
## Summary
- add `QuantumOverlay` to create a flashing overlay when the apocalypse is active
- extend `User` type and mock data with a `badges` array
- allow starting a "Quantum Bug Apocalypse" from the Bugs page
- reverse progress bars and scramble leaderboard during the storm
- record a "Quantum Survivor" badge when the storm ends

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
