### PR TITLE
Add Win95 taskbar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ const NewBug = lazy(() => import('./routes/NewBug'))
 const NotFound = lazy(() => import('./routes/NotFound'))
 import { Minus, Square, X as CloseIcon } from 'lucide-react'
 import { raised, windowShadow } from './utils/win95'
+import Taskbar from './components/Taskbar'
 
 function AppContent() {
   const location = useLocation()
@@ -59,104 +60,103 @@ function AppContent() {
 
   return (
     <div className="min-h-screen bg-[#008080] p-4 font-['MS_Sans_Serif','Tahoma',sans-serif] flex flex-col">
-      {minimized ? (
-        <div className="mx-auto">
-          <button
-            className={`px-4 py-1 bg-[#C0C0C0] ${raised}`}
-            onClick={() => setMinimized(false)}
-          >
-            {getWindowTitle()}
-          </button>
-        </div>
-      ) : (
-        <div
-          className={`mx-auto w-full flex-grow flex ${maximized ? '' : 'max-w-7xl'}`}
-        >
-          {/* Single Win95 Window */}
+      <div className="flex-grow flex justify-center">
+        {!minimized && (
           <div
-            className={`w-full bg-[#C0C0C0] ${raised} ${windowShadow} flex flex-col`}
+            className={`mx-auto w-full flex ${maximized ? '' : 'max-w-7xl'}`}
           >
-            {/* Title-bar */}
-            <div className="h-8 select-none border-b-2 border-b-white bg-[#000080] px-2 text-white z-10">
-              <div className="flex h-full items-center justify-between">
-                <span className="font-bold tracking-wider">
-                  {getWindowTitle()}
-                </span>
-                <div className="flex gap-px">
-                  {[
-                    {
-                      Icon: Minus,
-                      label: 'Minimize',
-                      onClick: () => setMinimized(true),
-                    },
-                    {
-                      Icon: Square,
-                      label: maximized ? 'Restore' : 'Maximize',
-                      onClick: () => setMaximized(v => !v),
-                    },
-                    {
-                      Icon: CloseIcon,
-                      label: 'Close',
-                      onClick: () => setHidden(true),
-                    },
-                  ].map(({ Icon, label, onClick }) => (
-                    <button
-                      key={label}
-                      aria-label={label}
-                      onClick={onClick}
-                      className={`flex h-6 w-6 items-center justify-center bg-[#C0C0C0] ${raised} transition-colors hover:bg-[#A0A0A0] active:bg-[#A0A0A0]`}
-                    >
-                      <Icon className="h-3 w-3 text-black" />
-                    </button>
-                  ))}
+            {/* Single Win95 Window */}
+            <div
+              className={`w-full bg-[#C0C0C0] ${raised} ${windowShadow} flex flex-col`}
+            >
+              {/* Title-bar */}
+              <div className="h-8 select-none border-b-2 border-b-white bg-[#000080] px-2 text-white z-10">
+                <div className="flex h-full items-center justify-between">
+                  <span className="font-bold tracking-wider">
+                    {getWindowTitle()}
+                  </span>
+                  <div className="flex gap-px">
+                    {[
+                      {
+                        Icon: Minus,
+                        label: 'Minimize',
+                        onClick: () => setMinimized(true),
+                      },
+                      {
+                        Icon: Square,
+                        label: maximized ? 'Restore' : 'Maximize',
+                        onClick: () => setMaximized(v => !v),
+                      },
+                      {
+                        Icon: CloseIcon,
+                        label: 'Close',
+                        onClick: () => setHidden(true),
+                      },
+                    ].map(({ Icon, label, onClick }) => (
+                      <button
+                        key={label}
+                        aria-label={label}
+                        onClick={onClick}
+                        className={`flex h-6 w-6 items-center justify-center bg-[#C0C0C0] ${raised} transition-colors hover:bg-[#A0A0A0] active:bg-[#A0A0A0]`}
+                      >
+                        <Icon className="h-3 w-3 text-black" />
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              </div>
+
+              {/* Window Content Area */}
+              <div className="bg-[#E0E0E0] p-3 flex flex-col flex-grow">
+                {/* Navigation Tabs */}
+                <div className="mb-4 bg-[#C0C0C0] flex gap-1 p-1 sticky top-0 z-10">
+                  <Link
+                    to="/"
+                    className={`px-4 py-1 ${location.pathname === '/' ? 'bg-[#E0E0E0] font-semibold' : 'hover:bg-[#D0D0D0]'}`}
+                  >
+                    🐛 Bugs
+                  </Link>
+                  <Link
+                    to="/dashboard"
+                    className={`px-4 py-1 ${location.pathname === '/dashboard' ? 'bg-[#E0E0E0] font-semibold' : 'hover:bg-[#D0D0D0]'}`}
+                  >
+                    📊 Dashboard
+                  </Link>
+                  <Link
+                    to="/bounty-leaderboard"
+                    className={`px-4 py-1 ${location.pathname === '/bounty-leaderboard' ? 'bg-[#E0E0E0] font-semibold' : 'hover:bg-[#D0D0D0]'}`}
+                  >
+                    🏆 Leaderboard
+                  </Link>
+                </div>
+
+                {/* Route Content */}
+                <div className="p-2 overflow-auto relative z-0 flex-grow flex flex-col">
+                  <Suspense fallback={<div className="p-4">Loading...</div>}>
+                    <Routes>
+                      <Route path="/" element={<Bugs />} />
+                      <Route path="/dashboard" element={<Dashboard />} />
+                      <Route
+                        path="/bounty-leaderboard"
+                        element={<Leaderboard />}
+                      />
+                      <Route path="/user/:userId" element={<UserProfile />} />
+                      <Route path="/bug/new" element={<NewBug />} />
+                      <Route path="*" element={<NotFound />} />
+                    </Routes>
+                  </Suspense>
                 </div>
               </div>
             </div>
-
-            {/* Window Content Area */}
-            <div className="bg-[#E0E0E0] p-3 flex flex-col flex-grow">
-              {/* Navigation Tabs */}
-              <div className="mb-4 bg-[#C0C0C0] flex gap-1 p-1 sticky top-0 z-10">
-                <Link
-                  to="/"
-                  className={`px-4 py-1 ${location.pathname === '/' ? 'bg-[#E0E0E0] font-semibold' : 'hover:bg-[#D0D0D0]'}`}
-                >
-                  🐛 Bugs
-                </Link>
-                <Link
-                  to="/dashboard"
-                  className={`px-4 py-1 ${location.pathname === '/dashboard' ? 'bg-[#E0E0E0] font-semibold' : 'hover:bg-[#D0D0D0]'}`}
-                >
-                  📊 Dashboard
-                </Link>
-                <Link
-                  to="/bounty-leaderboard"
-                  className={`px-4 py-1 ${location.pathname === '/bounty-leaderboard' ? 'bg-[#E0E0E0] font-semibold' : 'hover:bg-[#D0D0D0]'}`}
-                >
-                  🏆 Leaderboard
-                </Link>
-              </div>
-
-              {/* Route Content */}
-              <div className="p-2 overflow-auto relative z-0 flex-grow flex flex-col">
-                <Suspense fallback={<div className="p-4">Loading...</div>}>
-                  <Routes>
-                    <Route path="/" element={<Bugs />} />
-                    <Route path="/dashboard" element={<Dashboard />} />
-                    <Route
-                      path="/bounty-leaderboard"
-                      element={<Leaderboard />}
-                    />
-                    <Route path="/user/:userId" element={<UserProfile />} />
-                    <Route path="/bug/new" element={<NewBug />} />
-                    <Route path="*" element={<NotFound />} />
-                  </Routes>
-                </Suspense>
-              </div>
-            </div>
           </div>
-        </div>
-      )}
+        )}
+      </div>
+      <Taskbar
+        minimized={minimized}
+        hidden={hidden}
+        title={getWindowTitle()}
+        onShow={() => setMinimized(false)}
+      />
     </div>
   )
 }

--- a/src/components/Taskbar.tsx
+++ b/src/components/Taskbar.tsx
@@ -1,0 +1,50 @@
+import { raised, sunken } from '../utils/win95'
+import { useEffect, useState } from 'react'
+
+interface TaskbarProps {
+  minimized: boolean
+  hidden: boolean
+  title: string
+  onShow: () => void
+}
+
+export default function Taskbar({
+  minimized,
+  hidden,
+  title,
+  onShow,
+}: TaskbarProps) {
+  const [time, setTime] = useState(() => new Date())
+
+  useEffect(() => {
+    const id = setInterval(() => setTime(new Date()), 1000)
+    return () => clearInterval(id)
+  }, [])
+
+  return (
+    <div className="h-8 bg-[#C0C0C0] flex items-center px-1 border-t-2 border-t-white border-l-2 border-l-white border-b-2 border-b-gray-500 border-r-2 border-r-gray-500">
+      <button
+        className={`h-6 px-2 flex items-center gap-1 bg-[#C0C0C0] mr-1 ${raised} active:${sunken}`}
+      >
+        <svg viewBox="0 0 16 16" className="w-4 h-4" aria-hidden="true">
+          <path fill="#F35325" d="M0 0h7v7H0z" />
+          <path fill="#81BC06" d="M0 9h7v7H0z" />
+          <path fill="#05A6F0" d="M9 0h7v7H9z" />
+          <path fill="#FFBA08" d="M9 9h7v7H9z" />
+        </svg>
+        Start
+      </button>
+      {!hidden && (
+        <button
+          onClick={onShow}
+          className={`h-6 px-2 bg-[#C0C0C0] ${minimized ? raised : sunken}`}
+        >
+          {title}
+        </button>
+      )}
+      <div className="ml-auto px-2 text-xs">
+        {time.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add Taskbar component to emulate Windows 95 taskbar
- integrate Taskbar in `AppContent`
- refine taskbar appearance

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
