### PR TITLE
Refactor types into dedicated modules

### DIFF
--- a/src/components/AimCursor.tsx
+++ b/src/components/AimCursor.tsx
@@ -1,12 +1,8 @@
 import React from 'react'
-
-interface Props {
-  x: number
-  y: number
-}
+import type { AimCursorProps } from '../types/components/AimCursor'
 
 /** A simple red cross-hair that never intercepts pointer events. */
-const AimCursor: React.FC<Props> = ({ x, y }) => {
+const AimCursor: React.FC<AimCursorProps> = ({ x, y }) => {
   const size = 24
   const half = size / 2
 

--- a/src/components/BugArea.tsx
+++ b/src/components/BugArea.tsx
@@ -1,13 +1,10 @@
 import { useEffect, useMemo, useRef, useState, useCallback } from 'react'
-import { Bug } from '../types/bug'
 import BugCrawler from './BugCrawler'
 import AimCursor from './AimCursor'
 import { useBugStore } from '../store'
+import type { BugAreaProps } from '../types/components/BugArea'
 
 /** Evenly spreads bugs, then shuffles and jitters them for an organic layout. */
-interface BugAreaProps {
-  bugs: Bug[]
-}
 
 const SPEED = 320 // px per second the aim moves when an input is held/tilted
 const DEAD_ZONE = 0.15 // ignore tiny stick deflections

--- a/src/components/BugCard.tsx
+++ b/src/components/BugCard.tsx
@@ -1,16 +1,10 @@
 import { motion } from 'framer-motion'
-import { Bug } from '../types/bug'
 import { useBugStore } from '../store'
 import clsx from 'clsx'
 import { getBugImage } from '../utils/utils'
+import type { BugCardProps } from '../types/components/BugCard'
 
-interface Props {
-  bug: Bug
-  /** Compact hover preview when true */
-  preview?: boolean
-}
-
-export const BugCard: React.FC<Props> = ({ bug, preview = false }) => {
+export const BugCard: React.FC<BugCardProps> = ({ bug, preview = false }) => {
   const squashBug = useBugStore(s => s.squashBug)
   const bugImage = getBugImage(bug.id)
 

--- a/src/components/BugCrawler.tsx
+++ b/src/components/BugCrawler.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { motion } from 'framer-motion'
-import { Bug } from '../types/bug'
+import type { BugCrawlerProps } from '../types/components/BugCrawler'
 import { getBugImage } from '../utils/utils'
 import { BugCard } from './BugCard'
 import ReactDOM from 'react-dom'
@@ -10,13 +10,6 @@ import { useBugStore } from '../store'
 /** -----------------------------------------------------------------------
  *  BugCrawler — makes a bug sprite wander with a lightweight 3-D effect
  *  ---------------------------------------------------------------------- */
-interface BugCrawlerProps {
-  x: number
-  y: number
-  bug: Bug
-  containerWidth: number
-  containerHeight: number
-}
 
 const BugCrawler: React.FC<BugCrawlerProps> = ({
   x,

--- a/src/components/BugTrendsChart.tsx
+++ b/src/components/BugTrendsChart.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react'
 import * as d3 from 'd3'
+import type { DataPoint } from '../types/components/BugTrendsChart'
 import { Bug } from '../types/bug'
 
 /**
@@ -68,12 +69,6 @@ const BugTrendsChart = ({ bugs }: { bugs: Bug[] }) => {
         .attr('fill', '#6b7280') // gray-500
         .text('No data to display')
       return
-    }
-
-    interface DataPoint {
-      date: Date
-      created: number
-      resolved: number
     }
 
     const series = allDays.map(d => ({

--- a/src/components/Meta.tsx
+++ b/src/components/Meta.tsx
@@ -1,11 +1,5 @@
 import { useEffect } from 'react'
-
-interface MetaProps {
-  title: string
-  description: string
-  image?: string
-  structuredData?: Record<string, unknown>
-}
+import type { MetaProps } from '../types/components/Meta'
 
 export default function Meta({
   title,

--- a/src/components/Taskbar.tsx
+++ b/src/components/Taskbar.tsx
@@ -1,11 +1,6 @@
 import { useEffect, useState } from 'react'
 import { raised, sunken } from '../utils/win95'
-
-interface TaskbarProps {
-  windowTitle: string
-  minimized: boolean
-  onToggle: () => void
-}
+import type { TaskbarProps } from '../types/components/Taskbar'
 
 const getTime = () =>
   new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,11 +1,7 @@
 import * as React from 'react'
-import { type VariantProps } from 'class-variance-authority'
 import { cn } from '../../lib/utils'
 import { badgeVariants } from './badge-variants'
-
-export interface BadgeProps
-  extends React.HTMLAttributes<HTMLDivElement>,
-    VariantProps<typeof badgeVariants> {}
+import type { BadgeProps } from '../../types/ui/badge'
 
 function Badge({ className, variant, ...props }: BadgeProps) {
   return (

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,15 +1,8 @@
 import * as React from 'react'
 import { Slot } from '@radix-ui/react-slot'
-import { type VariantProps } from 'class-variance-authority'
-
 import { cn } from '../../lib/utils'
 import { buttonVariants } from './button-variants'
-
-export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonVariants> {
-  asChild?: boolean
-}
+import type { ButtonProps } from '../../types/ui/button'
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react'
-
-export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {}
+import type { InputProps } from '../../types/ui/input'
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, ...props }, ref) => {

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react'
-
-export interface LabelProps
-  extends React.LabelHTMLAttributes<HTMLLabelElement> {}
+import type { LabelProps } from '../../types/ui/label'
 
 const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
   ({ className, ...props }, ref) => {

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,21 +1,16 @@
 import * as React from 'react'
-
-interface SelectContextType<T extends string> {
-  value: T
-  onValueChange: (value: T) => void
-  open: boolean
-  setOpen: (open: boolean) => void
-}
+import type {
+  SelectContextType,
+  SelectProps,
+  SelectTriggerProps,
+  SelectValueProps,
+  SelectContentProps,
+  SelectItemProps,
+} from '../../types/ui/select'
 
 const SelectContext = React.createContext<
   SelectContextType<string> | undefined
 >(undefined)
-
-export interface SelectProps<T extends string> {
-  value: T
-  onValueChange: (value: T) => void
-  children: React.ReactNode
-}
 
 export function Select<T extends string>({
   children,
@@ -36,11 +31,6 @@ export function Select<T extends string>({
       {children}
     </SelectContext.Provider>
   )
-}
-
-export interface SelectTriggerProps {
-  className?: string
-  children: React.ReactNode
 }
 
 export function SelectTrigger({ className, children }: SelectTriggerProps) {
@@ -67,10 +57,6 @@ export function SelectTrigger({ className, children }: SelectTriggerProps) {
   )
 }
 
-export interface SelectValueProps {
-  placeholder: string
-}
-
 export function SelectValue({ placeholder }: SelectValueProps) {
   const context = React.useContext(SelectContext)
   if (!context) {
@@ -78,11 +64,6 @@ export function SelectValue({ placeholder }: SelectValueProps) {
   }
 
   return <span>{context.value || placeholder}</span>
-}
-
-export interface SelectContentProps {
-  className?: string
-  children: React.ReactNode
 }
 
 export function SelectContent({ className, children }: SelectContentProps) {
@@ -104,11 +85,6 @@ export function SelectContent({ className, children }: SelectContentProps) {
       </div>
     </div>
   )
-}
-
-export interface SelectItemProps<T extends string> {
-  value: T
-  children: React.ReactNode
 }
 
 export function SelectItem<T extends string>({

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react'
-
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+import type { TextareaProps } from '../../types/ui/textarea'
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/routes/Leaderboard.tsx
+++ b/src/routes/Leaderboard.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { useBugStore } from '../store'
 import Meta from '../components/Meta'
 import { Input } from '../components/ui/input'
+import type { SortKey } from '../types/routes/Leaderboard'
 
 /** Map bounty → tier name */
 const levelFromBounty = (bounty: number): string => {
@@ -19,8 +20,6 @@ const levelTier = (bounty: number): number => {
   if (bounty >= 2000) return 2
   return 1
 }
-
-type SortKey = 'rank' | 'name' | 'bugs' | 'bounty' | 'efficiency' | 'level'
 
 export default function Leaderboard() {
   const users = useBugStore(s => s.users)

--- a/src/store.ts
+++ b/src/store.ts
@@ -3,23 +3,7 @@ import { bugs as mockBugs } from './mock/bugs.ts'
 import { users as mockUsers } from './mock/users.ts'
 import { CONFIG, BUG_TEMPLATES } from './lib/store-constants.ts'
 import type { Bug } from './types/bug.ts'
-import type { User } from './types/user.ts'
-
-interface State {
-  bugs: Bug[]
-  users: User[]
-  activeUserId: number
-  inspectedId: string | null
-  quantumStormActive: boolean
-  inspectBug: (id: string | null) => void
-  squashBug: (id: string) => void
-  addBug: (bug: Bug) => void
-  removeBug: (id: string) => void
-  startQuantumStorm: () => void
-  stopQuantumStorm: () => void
-  startAutomaticSystems: () => void
-  stopAutomaticSystems: () => void
-}
+import type { State } from './types/store.ts'
 
 // Configuration and bug templates are defined in src/lib/store-constants.ts
 

--- a/src/types/components/AimCursor.ts
+++ b/src/types/components/AimCursor.ts
@@ -1,0 +1,4 @@
+export interface AimCursorProps {
+  x: number
+  y: number
+}

--- a/src/types/components/BugArea.ts
+++ b/src/types/components/BugArea.ts
@@ -1,0 +1,5 @@
+import type { Bug } from '../bug'
+
+export interface BugAreaProps {
+  bugs: Bug[]
+}

--- a/src/types/components/BugCard.ts
+++ b/src/types/components/BugCard.ts
@@ -1,0 +1,7 @@
+import type { Bug } from '../bug'
+
+export interface BugCardProps {
+  bug: Bug
+  /** Compact hover preview when true */
+  preview?: boolean
+}

--- a/src/types/components/BugCrawler.ts
+++ b/src/types/components/BugCrawler.ts
@@ -1,0 +1,9 @@
+import type { Bug } from '../bug'
+
+export interface BugCrawlerProps {
+  x: number
+  y: number
+  bug: Bug
+  containerWidth: number
+  containerHeight: number
+}

--- a/src/types/components/BugTrendsChart.ts
+++ b/src/types/components/BugTrendsChart.ts
@@ -1,0 +1,5 @@
+export interface DataPoint {
+  date: Date
+  created: number
+  resolved: number
+}

--- a/src/types/components/Meta.ts
+++ b/src/types/components/Meta.ts
@@ -1,0 +1,6 @@
+export interface MetaProps {
+  title: string
+  description: string
+  image?: string
+  structuredData?: Record<string, unknown>
+}

--- a/src/types/components/Taskbar.ts
+++ b/src/types/components/Taskbar.ts
@@ -1,0 +1,5 @@
+export interface TaskbarProps {
+  windowTitle: string
+  minimized: boolean
+  onToggle: () => void
+}

--- a/src/types/routes/Leaderboard.ts
+++ b/src/types/routes/Leaderboard.ts
@@ -1,0 +1,7 @@
+export type SortKey =
+  | 'rank'
+  | 'name'
+  | 'bugs'
+  | 'bounty'
+  | 'efficiency'
+  | 'level'

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -1,0 +1,18 @@
+import type { Bug } from './bug'
+import type { User } from './user'
+
+export interface State {
+  bugs: Bug[]
+  users: User[]
+  activeUserId: number
+  inspectedId: string | null
+  quantumStormActive: boolean
+  inspectBug: (id: string | null) => void
+  squashBug: (id: string) => void
+  addBug: (bug: Bug) => void
+  removeBug: (id: string) => void
+  startQuantumStorm: () => void
+  stopQuantumStorm: () => void
+  startAutomaticSystems: () => void
+  stopAutomaticSystems: () => void
+}

--- a/src/types/ui/badge.ts
+++ b/src/types/ui/badge.ts
@@ -1,0 +1,7 @@
+import * as React from 'react'
+import { type VariantProps } from 'class-variance-authority'
+import { badgeVariants } from '../../components/ui/badge-variants'
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}

--- a/src/types/ui/button.ts
+++ b/src/types/ui/button.ts
@@ -1,0 +1,9 @@
+import * as React from 'react'
+import { type VariantProps } from 'class-variance-authority'
+import { buttonVariants } from '../../components/ui/button-variants'
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+}

--- a/src/types/ui/input.ts
+++ b/src/types/ui/input.ts
@@ -1,0 +1,4 @@
+import * as React from 'react'
+
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {}

--- a/src/types/ui/label.ts
+++ b/src/types/ui/label.ts
@@ -1,0 +1,4 @@
+import * as React from 'react'
+
+export interface LabelProps
+  extends React.LabelHTMLAttributes<HTMLLabelElement> {}

--- a/src/types/ui/select.ts
+++ b/src/types/ui/select.ts
@@ -1,0 +1,33 @@
+import * as React from 'react'
+
+export interface SelectContextType<T extends string> {
+  value: T
+  onValueChange: (value: T) => void
+  open: boolean
+  setOpen: (open: boolean) => void
+}
+
+export interface SelectProps<T extends string> {
+  value: T
+  onValueChange: (value: T) => void
+  children: React.ReactNode
+}
+
+export interface SelectTriggerProps {
+  className?: string
+  children: React.ReactNode
+}
+
+export interface SelectValueProps {
+  placeholder: string
+}
+
+export interface SelectContentProps {
+  className?: string
+  children: React.ReactNode
+}
+
+export interface SelectItemProps<T extends string> {
+  value: T
+  children: React.ReactNode
+}

--- a/src/types/ui/textarea.ts
+++ b/src/types/ui/textarea.ts
@@ -1,0 +1,4 @@
+import * as React from 'react'
+
+export interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}


### PR DESCRIPTION
## Summary
- move component props and state definitions to `src/types`
- clean up unused imports after refactor

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
