### PR TITLE
Integrate ML bug priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ See [docs/NAMING_CONVENTIONS.md](docs/NAMING_CONVENTIONS.md) for the complete gu
 - `BugArea.tsx`: Where bugs live rent-free
 - `BugCard.tsx`: Instagram for insects
 - `BugCrawler.tsx`: AI pathfinding for 2D sprites
+- `bug-priority-ml.ts`: Logistic regression that pretends to rank urgency
 - `AimCursor.tsx`: Mouse cursor replacement nobody asked for
 
 **📊 Dashboard Extravaganza:**

--- a/src/components/BugCard.tsx
+++ b/src/components/BugCard.tsx
@@ -1,8 +1,9 @@
 import { motion } from 'framer-motion'
 import { Bug } from '../types/bug'
-import { useBugStore } from '../store'
+import { useBugStore, priorityModel } from '../store'
 import clsx from 'clsx'
 import { getBugImage } from '../utils/utils'
+import { predictPriorityProbability } from '../lib/bug-priority-ml.ts'
 
 interface Props {
   bug: Bug
@@ -13,6 +14,10 @@ interface Props {
 export const BugCard: React.FC<Props> = ({ bug, preview = false }) => {
   const squashBug = useBugStore(s => s.squashBug)
   const bugImage = getBugImage(bug.id)
+  const highProb =
+    priorityModel && bug.bounty
+      ? predictPriorityProbability(bug.bounty, priorityModel)
+      : null
 
   return (
     <motion.div
@@ -70,6 +75,23 @@ export const BugCard: React.FC<Props> = ({ bug, preview = false }) => {
           <span className="ml-2 inline-block rounded-full bg-emerald-600 px-2 py-1 text-xs font-mono text-white">
             +{bug.bounty}
           </span>
+          {bug.priority && (
+            <span
+              className={clsx(
+                'ml-2 inline-block rounded-full px-2 py-1 text-xs font-mono text-white',
+                bug.priority === 'high' && 'bg-red-600',
+                bug.priority === 'medium' && 'bg-yellow-500',
+                bug.priority === 'low' && 'bg-gray-500'
+              )}
+            >
+              {bug.priority}
+            </span>
+          )}
+          {highProb !== null && (
+            <span className="ml-2 text-xs text-gray-500 font-mono">
+              {Math.round(highProb * 100)}%
+            </span>
+          )}
         </div>
 
         <p className="mb-4 mx-4 text-sm text-gray-600">{bug.description}</p>

--- a/src/lib/bug-priority-ml.test.ts
+++ b/src/lib/bug-priority-ml.test.ts
@@ -1,0 +1,17 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { trainPriorityModel, predictPriority } from './bug-priority-ml.ts'
+import { bugs } from '../mock/bugs.ts'
+
+test('priority model predicts high priority for large bounty', () => {
+  const model = trainPriorityModel(bugs)
+  const highBug = { ...bugs[0], bounty: 250 }
+  assert.strictEqual(predictPriority(highBug, model), 'high')
+})
+
+test('priority model predicts low or medium for small bounty', () => {
+  const model = trainPriorityModel(bugs)
+  const lowBug = { ...bugs[0], bounty: 20 }
+  const result = predictPriority(lowBug, model)
+  assert.ok(result === 'low' || result === 'medium')
+})

--- a/src/lib/bug-priority-ml.ts
+++ b/src/lib/bug-priority-ml.ts
@@ -1,0 +1,52 @@
+import type { Bug } from '../types/bug.ts'
+
+export interface PriorityModel {
+  weight: number
+  bias: number
+}
+
+const sigmoid = (z: number) => 1 / (1 + Math.exp(-z))
+
+export const trainPriorityModel = (
+  bugs: Bug[],
+  iterations = 3000,
+  learningRate = 0.1
+): PriorityModel => {
+  let weight = 0
+  let bias = 0
+  // Normalize bounty to keep gradients reasonable
+  const xs = bugs.map(b => b.bounty / 200)
+  const ys = bugs.map(b => (b.priority === 'high' ? 1 : 0))
+
+  for (let i = 0; i < iterations; i++) {
+    let dw = 0
+    let db = 0
+    for (let j = 0; j < xs.length; j++) {
+      const x = xs[j]
+      const y = ys[j]
+      const pred = sigmoid(weight * x + bias)
+      dw += (pred - y) * x
+      db += pred - y
+    }
+    weight -= (learningRate / xs.length) * dw
+    bias -= (learningRate / xs.length) * db
+  }
+  return { weight, bias }
+}
+
+export const predictPriorityProbability = (
+  bounty: number,
+  model: PriorityModel
+): number => {
+  return sigmoid(model.weight * (bounty / 200) + model.bias)
+}
+
+export const predictPriority = (
+  bug: Bug,
+  model: PriorityModel
+): 'high' | 'medium' | 'low' => {
+  const prob = predictPriorityProbability(bug.bounty, model)
+  if (prob > 0.66) return 'high'
+  if (prob > 0.33) return 'medium'
+  return 'low'
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -4,6 +4,8 @@ import { users as mockUsers } from './mock/users.ts'
 import { CONFIG, BUG_TEMPLATES } from './lib/store-constants.ts'
 import type { Bug } from './types/bug.ts'
 import type { User } from './types/user.ts'
+import { trainPriorityModel, predictPriority } from './lib/bug-priority-ml.ts'
+import type { PriorityModel } from './lib/bug-priority-ml.ts'
 
 interface State {
   bugs: Bug[]
@@ -27,6 +29,12 @@ let cleanupTimer: ReturnType<typeof setInterval> | null = null
 let respawnTimer: ReturnType<typeof setInterval> | null = null
 let stormTimer: ReturnType<typeof setInterval> | null = null
 let stormBugIds: string[] = []
+
+// Train a simple logistic regression model using the mock bugs
+export let priorityModel: PriorityModel | null = null
+if (mockBugs.length) {
+  priorityModel = trainPriorityModel(mockBugs)
+}
 
 export const useBugStore = create<State>((set, get) => ({
   bugs: mockBugs,
@@ -81,12 +89,19 @@ export const useBugStore = create<State>((set, get) => ({
         BUG_TEMPLATES[Math.floor(Math.random() * BUG_TEMPLATES.length)]
       const id = `storm-${Date.now()}-${i}`
       stormBugIds.push(id)
+
+      const bounty = Math.floor(Math.random() * 50) + 10
+      const priority = priorityModel
+        ? predictPriority({ bounty } as Bug, priorityModel)
+        : 'low'
+
       extras.push({
         id,
         title: template.title,
         description: template.description,
-        bounty: Math.floor(Math.random() * 50) + 10,
+        bounty,
         active: true,
+        priority,
         createdAt: new Date().toISOString(),
       })
     }
@@ -147,19 +162,25 @@ export const useBugStore = create<State>((set, get) => ({
         for (let i = 0; i < bugsToSpawn; i++) {
           const template =
             BUG_TEMPLATES[Math.floor(Math.random() * BUG_TEMPLATES.length)]
-          const priorities: ('high' | 'medium' | 'low')[] = [
-            'high',
-            'medium',
-            'low',
-          ]
-          const priority =
-            priorities[Math.floor(Math.random() * priorities.length)]
+
+          const bounty = Math.floor(Math.random() * 180) + 20 // 20-200 bounty
+          let priority: 'high' | 'medium' | 'low'
+          if (priorityModel) {
+            priority = predictPriority({ bounty } as Bug, priorityModel)
+          } else {
+            const priorities: ('high' | 'medium' | 'low')[] = [
+              'high',
+              'medium',
+              'low',
+            ]
+            priority = priorities[Math.floor(Math.random() * priorities.length)]
+          }
 
           const newBug: Bug = {
             id: `auto-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
             title: template.title,
             description: template.description,
-            bounty: Math.floor(Math.random() * 180) + 20, // 20-200 bounty
+            bounty,
             active: true,
             priority,
             createdAt: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- train logistic regression model at store startup
- predict priority when spawning new bugs and during storms
- expose model and show probability badge in BugCard

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
