### PR TITLE
Extract type definitions

### DIFF
--- a/src/components/AimCursor.tsx
+++ b/src/components/AimCursor.tsx
@@ -1,12 +1,8 @@
 import React from 'react'
-
-interface Props {
-  x: number
-  y: number
-}
+import type { AimCursorProps } from '../types/aim-cursor-props'
 
 /** A simple red cross-hair that never intercepts pointer events. */
-const AimCursor: React.FC<Props> = ({ x, y }) => {
+const AimCursor: React.FC<AimCursorProps> = ({ x, y }) => {
   const size = 24
   const half = size / 2
 

--- a/src/components/BugArea.tsx
+++ b/src/components/BugArea.tsx
@@ -1,14 +1,11 @@
 import { useEffect, useMemo, useRef, useState, useCallback } from 'react'
 import { useElementSize } from '../hooks/use-element-size'
-import { Bug } from '../types/bug'
+import type { BugAreaProps } from '../types/bug-area-props'
 import BugCrawler from './BugCrawler'
 import AimCursor from './AimCursor'
 import { useBugStore } from '../store'
 
 /** Evenly spreads bugs, then shuffles and jitters them for an organic layout. */
-interface BugAreaProps {
-  bugs: Bug[]
-}
 
 const SPEED = 320 // px per second the aim moves when an input is held/tilted
 const DEAD_ZONE = 0.15 // ignore tiny stick deflections

--- a/src/components/BugCard.tsx
+++ b/src/components/BugCard.tsx
@@ -1,17 +1,11 @@
 import { motion } from 'framer-motion'
-import { Bug } from '../types/bug'
+import type { BugCardProps } from '../types/bug-card-props'
 import { useBugStore, priorityModel } from '../store'
 import clsx from 'clsx'
 import { getBugImage } from '../utils/utils'
 import { predictPriorityProbability } from '../lib/bug-priority-ml.ts'
 
-interface Props {
-  bug: Bug
-  /** Compact hover preview when true */
-  preview?: boolean
-}
-
-export const BugCard: React.FC<Props> = ({ bug, preview = false }) => {
+export const BugCard: React.FC<BugCardProps> = ({ bug, preview = false }) => {
   const squashBug = useBugStore(s => s.squashBug)
   const bugImage = getBugImage(bug.id)
   const highProb =

--- a/src/components/BugCrawler.tsx
+++ b/src/components/BugCrawler.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { motion } from 'framer-motion'
-import { Bug } from '../types/bug'
+import type { BugCrawlerProps } from '../types/bug-crawler-props'
 import { getBugImage } from '../utils/utils'
 import { BugCard } from './BugCard'
 import ReactDOM from 'react-dom'
@@ -10,13 +10,6 @@ import { useBugStore } from '../store'
 /** -----------------------------------------------------------------------
  *  BugCrawler — makes a bug sprite wander with a lightweight 3-D effect
  *  ---------------------------------------------------------------------- */
-interface BugCrawlerProps {
-  x: number
-  y: number
-  bug: Bug
-  containerWidth: number
-  containerHeight: number
-}
 
 const BugCrawler: React.FC<BugCrawlerProps> = ({
   x,

--- a/src/components/BugTrendsChart.tsx
+++ b/src/components/BugTrendsChart.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react'
 import { useElementSize } from '../hooks/use-element-size'
 import * as d3 from 'd3'
 import { Bug } from '../types/bug'
+import type { DataPoint } from '../types/bug-trends-chart'
 
 /**
  * Interactive line chart that tracks how many bugs were reported
@@ -69,12 +70,6 @@ const BugTrendsChart = ({ bugs }: { bugs: Bug[] }) => {
         .attr('fill', '#6b7280') // gray-500
         .text('No data to display')
       return
-    }
-
-    interface DataPoint {
-      date: Date
-      created: number
-      resolved: number
     }
 
     const series = allDays.map(d => ({

--- a/src/components/Meta.tsx
+++ b/src/components/Meta.tsx
@@ -1,11 +1,5 @@
 import { useEffect } from 'react'
-
-interface MetaProps {
-  title: string
-  description: string
-  image?: string
-  structuredData?: Record<string, unknown>
-}
+import type { MetaProps } from '../types/meta-props'
 
 export default function Meta({
   title,

--- a/src/components/Taskbar.tsx
+++ b/src/components/Taskbar.tsx
@@ -1,11 +1,6 @@
 import { useEffect, useState } from 'react'
 import { raised, sunken } from '../utils/win95'
-
-interface TaskbarProps {
-  windowTitle: string
-  minimized: boolean
-  onToggle: () => void
-}
+import type { TaskbarProps } from '../types/taskbar-props'
 
 const getTime = () =>
   new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,11 +1,7 @@
 import * as React from 'react'
-import { type VariantProps } from 'class-variance-authority'
 import { cn } from '../../lib/utils'
 import { badgeVariants } from './badge-variants'
-
-export interface BadgeProps
-  extends React.HTMLAttributes<HTMLDivElement>,
-    VariantProps<typeof badgeVariants> {}
+import type { BadgeProps } from '../../types/badge-props'
 
 function Badge({ className, variant, ...props }: BadgeProps) {
   return (

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,15 +1,9 @@
 import * as React from 'react'
 import { Slot } from '@radix-ui/react-slot'
-import { type VariantProps } from 'class-variance-authority'
 
 import { cn } from '../../lib/utils'
 import { buttonVariants } from './button-variants'
-
-export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonVariants> {
-  asChild?: boolean
-}
+import type { ButtonProps } from '../../types/button-props'
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react'
-
-export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {}
+import type { InputProps } from '../../types/input-props'
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, ...props }, ref) => {

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react'
-
-export interface LabelProps
-  extends React.LabelHTMLAttributes<HTMLLabelElement> {}
+import type { LabelProps } from '../../types/label-props'
 
 const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
   ({ className, ...props }, ref) => {

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,21 +1,16 @@
 import * as React from 'react'
-
-interface SelectContextType<T extends string> {
-  value: T
-  onValueChange: (value: T) => void
-  open: boolean
-  setOpen: (open: boolean) => void
-}
+import type {
+  SelectContextType,
+  SelectProps,
+  SelectTriggerProps,
+  SelectValueProps,
+  SelectContentProps,
+  SelectItemProps,
+} from '../../types/select-props'
 
 const SelectContext = React.createContext<
   SelectContextType<string> | undefined
 >(undefined)
-
-export interface SelectProps<T extends string> {
-  value: T
-  onValueChange: (value: T) => void
-  children: React.ReactNode
-}
 
 export function Select<T extends string>({
   children,
@@ -36,11 +31,6 @@ export function Select<T extends string>({
       {children}
     </SelectContext.Provider>
   )
-}
-
-export interface SelectTriggerProps {
-  className?: string
-  children: React.ReactNode
 }
 
 export function SelectTrigger({ className, children }: SelectTriggerProps) {
@@ -67,10 +57,6 @@ export function SelectTrigger({ className, children }: SelectTriggerProps) {
   )
 }
 
-export interface SelectValueProps {
-  placeholder: string
-}
-
 export function SelectValue({ placeholder }: SelectValueProps) {
   const context = React.useContext(SelectContext)
   if (!context) {
@@ -78,11 +64,6 @@ export function SelectValue({ placeholder }: SelectValueProps) {
   }
 
   return <span>{context.value || placeholder}</span>
-}
-
-export interface SelectContentProps {
-  className?: string
-  children: React.ReactNode
 }
 
 export function SelectContent({ className, children }: SelectContentProps) {
@@ -104,11 +85,6 @@ export function SelectContent({ className, children }: SelectContentProps) {
       </div>
     </div>
   )
-}
-
-export interface SelectItemProps<T extends string> {
-  value: T
-  children: React.ReactNode
 }
 
 export function SelectItem<T extends string>({

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react'
-
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+import type { TextareaProps } from '../../types/textarea-props'
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/hooks/use-element-size.ts
+++ b/src/hooks/use-element-size.ts
@@ -1,9 +1,5 @@
 import { useEffect, useState } from 'react'
-
-export interface ElementSize {
-  width: number
-  height: number
-}
+import type { ElementSize } from '../types/element-size'
 
 export const useElementSize = <T extends HTMLElement>(
   ref: React.RefObject<T>

--- a/src/lib/bug-priority-ml.ts
+++ b/src/lib/bug-priority-ml.ts
@@ -1,9 +1,5 @@
 import type { Bug } from '../types/bug.ts'
-
-export interface PriorityModel {
-  weight: number
-  bias: number
-}
+import type { PriorityModel } from '../types/priority-model'
 
 const sigmoid = (z: number) => 1 / (1 + Math.exp(-z))
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -3,22 +3,9 @@ import { bugs as mockBugs } from './mock/bugs.ts'
 import { users as mockUsers } from './mock/users.ts'
 import { CONFIG, BUG_TEMPLATES } from './lib/store-constants.ts'
 import type { Bug } from './types/bug.ts'
-import type { User } from './types/user.ts'
 import { trainPriorityModel, predictPriority } from './lib/bug-priority-ml.ts'
-import type { PriorityModel } from './lib/bug-priority-ml.ts'
-
-interface State {
-  bugs: Bug[]
-  users: User[]
-  activeUserId: number
-  inspectedId: string | null
-  inspectBug: (id: string | null) => void
-  squashBug: (id: string) => void
-  addBug: (bug: Bug) => void
-  removeBug: (id: string) => void
-  startAutomaticSystems: () => void
-  stopAutomaticSystems: () => void
-}
+import type { PriorityModel } from './types/priority-model'
+import type { StoreState } from './types/store-state'
 
 // Configuration and bug templates are defined in src/lib/store-constants.ts
 
@@ -31,7 +18,7 @@ if (mockBugs.length) {
   priorityModel = trainPriorityModel(mockBugs)
 }
 
-export const useBugStore = create<State>((set, get) => ({
+export const useBugStore = create<StoreState>((set, get) => ({
   bugs: mockBugs,
   users: mockUsers.sort((a, b) => b.bounty - a.bounty),
   activeUserId: 1, // assume first user is the current hacker

--- a/src/types/aim-cursor-props.ts
+++ b/src/types/aim-cursor-props.ts
@@ -1,0 +1,4 @@
+export interface AimCursorProps {
+  x: number
+  y: number
+}

--- a/src/types/badge-props.ts
+++ b/src/types/badge-props.ts
@@ -1,0 +1,6 @@
+import type { VariantProps } from 'class-variance-authority'
+import { badgeVariants } from '../components/ui/badge-variants'
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}

--- a/src/types/bug-area-props.ts
+++ b/src/types/bug-area-props.ts
@@ -1,0 +1,5 @@
+import type { Bug } from './bug'
+
+export interface BugAreaProps {
+  bugs: Bug[]
+}

--- a/src/types/bug-card-props.ts
+++ b/src/types/bug-card-props.ts
@@ -1,0 +1,7 @@
+import type { Bug } from './bug'
+
+export interface BugCardProps {
+  bug: Bug
+  /** Compact hover preview when true */
+  preview?: boolean
+}

--- a/src/types/bug-crawler-props.ts
+++ b/src/types/bug-crawler-props.ts
@@ -1,0 +1,9 @@
+import type { Bug } from './bug'
+
+export interface BugCrawlerProps {
+  x: number
+  y: number
+  bug: Bug
+  containerWidth: number
+  containerHeight: number
+}

--- a/src/types/bug-trends-chart.ts
+++ b/src/types/bug-trends-chart.ts
@@ -1,0 +1,5 @@
+export interface DataPoint {
+  date: Date
+  created: number
+  resolved: number
+}

--- a/src/types/button-props.ts
+++ b/src/types/button-props.ts
@@ -1,0 +1,8 @@
+import type { VariantProps } from 'class-variance-authority'
+import { buttonVariants } from '../components/ui/button-variants'
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+}

--- a/src/types/element-size.ts
+++ b/src/types/element-size.ts
@@ -1,0 +1,4 @@
+export interface ElementSize {
+  width: number
+  height: number
+}

--- a/src/types/input-props.ts
+++ b/src/types/input-props.ts
@@ -1,0 +1,2 @@
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {}

--- a/src/types/label-props.ts
+++ b/src/types/label-props.ts
@@ -1,0 +1,2 @@
+export interface LabelProps
+  extends React.LabelHTMLAttributes<HTMLLabelElement> {}

--- a/src/types/meta-props.ts
+++ b/src/types/meta-props.ts
@@ -1,0 +1,6 @@
+export interface MetaProps {
+  title: string
+  description: string
+  image?: string
+  structuredData?: Record<string, unknown>
+}

--- a/src/types/priority-model.ts
+++ b/src/types/priority-model.ts
@@ -1,0 +1,4 @@
+export interface PriorityModel {
+  weight: number
+  bias: number
+}

--- a/src/types/select-props.ts
+++ b/src/types/select-props.ts
@@ -1,0 +1,31 @@
+export interface SelectContextType<T extends string> {
+  value: T
+  onValueChange: (value: T) => void
+  open: boolean
+  setOpen: (open: boolean) => void
+}
+
+export interface SelectProps<T extends string> {
+  value: T
+  onValueChange: (value: T) => void
+  children: React.ReactNode
+}
+
+export interface SelectTriggerProps {
+  className?: string
+  children: React.ReactNode
+}
+
+export interface SelectValueProps {
+  placeholder: string
+}
+
+export interface SelectContentProps {
+  className?: string
+  children: React.ReactNode
+}
+
+export interface SelectItemProps<T extends string> {
+  value: T
+  children: React.ReactNode
+}

--- a/src/types/store-state.ts
+++ b/src/types/store-state.ts
@@ -1,0 +1,15 @@
+import type { Bug } from './bug'
+import type { User } from './user'
+
+export interface StoreState {
+  bugs: Bug[]
+  users: User[]
+  activeUserId: number
+  inspectedId: string | null
+  inspectBug: (id: string | null) => void
+  squashBug: (id: string) => void
+  addBug: (bug: Bug) => void
+  removeBug: (id: string) => void
+  startAutomaticSystems: () => void
+  stopAutomaticSystems: () => void
+}

--- a/src/types/taskbar-props.ts
+++ b/src/types/taskbar-props.ts
@@ -1,0 +1,5 @@
+export interface TaskbarProps {
+  windowTitle: string
+  minimized: boolean
+  onToggle: () => void
+}

--- a/src/types/textarea-props.ts
+++ b/src/types/textarea-props.ts
@@ -1,0 +1,2 @@
+export interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}


### PR DESCRIPTION
## Summary
- move interfaces into new files under `src/types`
- update imports to use the extracted types

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
