### PR TITLE
Fix modal overflow

### DIFF
--- a/src/components/BugCard.tsx
+++ b/src/components/BugCard.tsx
@@ -5,7 +5,11 @@ import clsx from 'clsx'
 import { getBugImage } from '../utils/utils'
 import { predictPriorityProbability } from '../lib/bug-priority-ml.ts'
 
-export const BugCard: React.FC<BugCardProps> = ({ bug, preview = false }) => {
+export const BugCard: React.FC<BugCardProps> = ({
+  bug,
+  preview = false,
+  modal = false,
+}) => {
   const squashBug = useBugStore(s => s.squashBug)
   const bugImage = getBugImage(bug.id)
   const highProb =
@@ -24,7 +28,7 @@ export const BugCard: React.FC<BugCardProps> = ({ bug, preview = false }) => {
       className={clsx(
         'relative overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-lg transition',
         !bug.active && 'opacity-40 grayscale',
-        preview ? 'w-[200px]' : 'w-80'
+        preview ? 'w-[200px]' : modal ? 'w-[90vw] max-w-sm sm:max-w-md' : 'w-80'
       )}
       onClick={e => {
         e.stopPropagation()
@@ -58,7 +62,10 @@ export const BugCard: React.FC<BugCardProps> = ({ bug, preview = false }) => {
           <img
             src={bugImage}
             alt={bug.title}
-            className="h-full w-full object-cover aspect-square mb-2"
+            className={clsx(
+              'w-full object-cover mb-2',
+              modal ? 'h-40' : 'h-full aspect-square'
+            )}
           />
         )}
 

--- a/src/components/BugCrawler.tsx
+++ b/src/components/BugCrawler.tsx
@@ -180,7 +180,7 @@ const BugCrawler: React.FC<BugCrawlerProps> = ({
       {/* modal on click */}
       {showModal && isAlive && (
         <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/20"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/20 p-4"
           ref={modalRef}
           tabIndex={-1}
           onClick={e => {
@@ -200,11 +200,11 @@ const BugCrawler: React.FC<BugCrawlerProps> = ({
                 e.stopPropagation()
                 inspectBug(null)
               }}
-              className="absolute -top-8 -right-8 size-8 rounded-full bg-white p-1"
+              className="absolute top-2 right-2 size-8 rounded-full bg-white p-1"
             >
               ✕
             </button>
-            <BugCard bug={bug} />
+            <BugCard bug={bug} modal />
           </div>
         </div>
       )}

--- a/src/types/bug-card-props.ts
+++ b/src/types/bug-card-props.ts
@@ -4,4 +4,6 @@ export interface BugCardProps {
   bug: Bug
   /** Compact hover preview when true */
   preview?: boolean
+  /** Shown inside a modal */
+  modal?: boolean
 }


### PR DESCRIPTION
## Summary
- tweak modal layout to avoid clipping without scrolling

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
