### PR TITLE
Add Konami code dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ This is a "bug bounty hackathon" project that ironically has more bugs than it f
 - 🔍 **Search & Filter**: Hunt bugs and leaderboard entries like a pro
 - 🧹 **Automatic Cleanup**: Squashed bugs vanish on their own, only to respawn
 - 🚫 **Comical 404 Page**: Getting lost has never been so entertaining
+- 🌑 **Konami Code Dark Mode**: Enter the secret code for a darker UI
 
 ### 🎪 The Technology Circus
 

--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
       }
     </script>
   </head>
-  <body class="min-h-screen bg-gray-50 antialiased">
+  <body class="min-h-screen bg-gray-50 antialiased dark:bg-gray-900">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import {
   Link,
 } from 'react-router-dom'
 import { Suspense, lazy, useEffect, useState } from 'react'
+import { useKonamiDarkMode } from './hooks/use-konami-dark-mode'
 import { useBugStore } from './store'
 
 const Bugs = lazy(() => import('./routes/Bugs'))
@@ -24,6 +25,7 @@ function AppContent() {
   const [minimized, setMinimized] = useState(false)
   const [maximized, setMaximized] = useState(false)
   const [hidden, setHidden] = useState(false)
+  useKonamiDarkMode()
 
   useEffect(() => {
     startAutomaticSystems()

--- a/src/hooks/use-konami-dark-mode.ts
+++ b/src/hooks/use-konami-dark-mode.ts
@@ -1,0 +1,40 @@
+import { useEffect } from 'react'
+
+const CODE = [
+  'ArrowUp',
+  'ArrowUp',
+  'ArrowDown',
+  'ArrowDown',
+  'ArrowLeft',
+  'ArrowRight',
+  'ArrowLeft',
+  'ArrowRight',
+  'b',
+  'a',
+]
+
+export const useKonamiDarkMode = () => {
+  useEffect(() => {
+    let index = 0
+    const handler = (e: KeyboardEvent) => {
+      const key = e.key
+      const expected = CODE[index]
+      if (
+        key === expected ||
+        (expected === 'b' && key.toLowerCase() === 'b') ||
+        (expected === 'a' && key.toLowerCase() === 'a')
+      ) {
+        index += 1
+        if (index === CODE.length) {
+          document.documentElement.classList.toggle('dark')
+          index = 0
+        }
+      } else {
+        index = key === CODE[0] ? 1 : 0
+      }
+    }
+
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [])
+}


### PR DESCRIPTION
## Summary
- enable a dark theme by entering the Konami code
- call the new hook from `AppContent`
- update body class to support dark background
- document the hidden feature

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
