### PR TITLE
Add weather forecast page

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ This is a "bug bounty hackathon" project that ironically has more bugs than it f
 - 🔍 **Search & Filter**: Hunt bugs and leaderboard entries like a pro
 - 🧹 **Automatic Cleanup**: Squashed bugs vanish on their own, only to respawn
 - 🚫 **Comical 404 Page**: Getting lost has never been so entertaining
+- 🌦️ **Weather Forecast**: Plan your bug hunts around the faux forecast
 - 🌑 **Konami Code Dark Mode**: Enter the secret code for a darker UI
 
 ### 🎪 The Technology Circus

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ const Dashboard = lazy(() => import('./routes/Dashboard'))
 const NewBug = lazy(() => import('./routes/NewBug'))
 const NotFound = lazy(() => import('./routes/NotFound'))
 const EasterEgg = lazy(() => import('./routes/EasterEgg'))
+const Weather = lazy(() => import('./routes/Weather'))
 import { Minus, Square, X as CloseIcon } from 'lucide-react'
 import { raised, windowShadow } from './utils/win95'
 import Taskbar from './components/Taskbar'
@@ -45,6 +46,8 @@ function AppContent() {
         return 'File a Bug'
       case '/easter-egg':
         return 'Secret Bug Found'
+      case '/weather':
+        return 'Weather Forecast'
       default:
         if (location.pathname.startsWith('/user/')) return 'User Profile'
         return 'Page Not Found'
@@ -141,6 +144,12 @@ function AppContent() {
                   >
                     🏆 Leaderboard
                   </Link>
+                  <Link
+                    to="/weather"
+                    className={`px-4 py-1 ${location.pathname === '/weather' ? 'bg-[#E0E0E0] font-semibold' : 'hover:bg-[#D0D0D0]'}`}
+                  >
+                    🌦️ Weather
+                  </Link>
                 </div>
 
                 {/* Route Content */}
@@ -153,6 +162,7 @@ function AppContent() {
                         path="/bounty-leaderboard"
                         element={<Leaderboard />}
                       />
+                      <Route path="/weather" element={<Weather />} />
                       <Route path="/user/:userId" element={<UserProfile />} />
                       <Route path="/bug/new" element={<NewBug />} />
                       <Route path="/easter-egg" element={<EasterEgg />} />

--- a/src/mock/weather.ts
+++ b/src/mock/weather.ts
@@ -1,0 +1,16 @@
+import type { ForecastDay } from '../types/weather'
+
+const today = new Date()
+const addDays = (n: number) => {
+  const d = new Date(today)
+  d.setDate(d.getDate() + n)
+  return d.toISOString()
+}
+
+export const forecast: ForecastDay[] = [
+  { date: addDays(0), condition: 'sunny', high: 26, low: 15 },
+  { date: addDays(1), condition: 'cloudy', high: 24, low: 14 },
+  { date: addDays(2), condition: 'rainy', high: 22, low: 12 },
+  { date: addDays(3), condition: 'sunny', high: 27, low: 16 },
+  { date: addDays(4), condition: 'snow', high: 10, low: 2 },
+]

--- a/src/routes/Weather.tsx
+++ b/src/routes/Weather.tsx
@@ -1,0 +1,58 @@
+import Meta from '../components/Meta'
+import { forecast } from '../mock/weather'
+import { raised as raisedBase } from '../utils/win95'
+import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card'
+import { SunIcon, CloudIcon, CloudRainIcon, SnowflakeIcon } from 'lucide-react'
+import type { ForecastDay } from '../types/weather'
+
+const iconFor = (condition: ForecastDay['condition']) => {
+  switch (condition) {
+    case 'sunny':
+      return <SunIcon className="h-5 w-5 text-amber-500" />
+    case 'cloudy':
+      return <CloudIcon className="h-5 w-5 text-gray-500" />
+    case 'rainy':
+      return <CloudRainIcon className="h-5 w-5 text-blue-500" />
+    case 'snow':
+      return <SnowflakeIcon className="h-5 w-5 text-indigo-400" />
+  }
+}
+
+const formatDate = (date: string) =>
+  new Intl.DateTimeFormat('en-US', {
+    weekday: 'long',
+    month: 'short',
+    day: 'numeric',
+  }).format(new Date(date))
+
+export default function Weather() {
+  const raised = `${raisedBase} shadow-sm`
+
+  return (
+    <>
+      <Meta
+        title="Weather Forecast"
+        description="Check the upcoming weather for your next bug hunt."
+      />
+      <div className="space-y-4">
+        <h1 className="text-2xl font-bold">Weather Forecast</h1>
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {forecast.map(day => (
+            <Card key={day.date} className={`bg-[#E0E0E0] ${raised}`}>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  {iconFor(day.condition)}
+                  {formatDate(day.date)}
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="flex justify-between text-sm">
+                <span>High: {day.high}°C</span>
+                <span>Low: {day.low}°C</span>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/types/weather.ts
+++ b/src/types/weather.ts
@@ -1,0 +1,6 @@
+export interface ForecastDay {
+  date: string
+  condition: 'sunny' | 'cloudy' | 'rainy' | 'snow'
+  high: number
+  low: number
+}


### PR DESCRIPTION
## Summary
- create `Weather.tsx` page with static forecast data
- add mock forecast data and type definitions
- link new page from the navigation
- document the forecast feature in the README

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683a356050e0832aad7ade097742003a