### PR TITLE
Add bug forecast feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ This is a "bug bounty hackathon" project that ironically has more bugs than it f
 - 🖥️ **Windows 95 Taskbar**: Because productivity peaks with a retro clock
 - 🔍 **Search & Filter**: Hunt bugs and leaderboard entries like a pro
 - 🧹 **Automatic Cleanup**: Squashed bugs vanish on their own, only to respawn
+- 🔮 **Bug Forecast**: Peer into tomorrow's infestation with predictive charts
 - 🚫 **Comical 404 Page**: Getting lost has never been so entertaining
 - 🌑 **Konami Code Dark Mode**: Enter the secret code for a darker UI
 

--- a/src/components/BugForecast.tsx
+++ b/src/components/BugForecast.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useRef } from 'react'
+import * as d3 from 'd3'
+import { Bug } from '../types/bug'
+import { forecastBugCounts } from '../lib/bug-forecast'
+import { useElementSize } from '../hooks/use-element-size'
+
+const BugForecast = ({ bugs }: { bugs: Bug[] }) => {
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  const svgRef = useRef<SVGSVGElement | null>(null)
+  const size = useElementSize(wrapperRef)
+
+  const data = forecastBugCounts(bugs, 7)
+
+  const renderChart = () => {
+    if (!svgRef.current || !size.width) return
+
+    const width = size.width
+    const height = 160
+    const margin = { top: 20, right: 20, bottom: 20, left: 30 }
+    const innerWidth = width - margin.left - margin.right
+    const innerHeight = height - margin.top - margin.bottom
+
+    const svg = d3.select(svgRef.current)
+    svg.selectAll('*').remove()
+    svg
+      .attr('width', width)
+      .attr('height', height)
+      .attr('viewBox', `0 0 ${width} ${height}`)
+      .attr('preserveAspectRatio', 'xMidYMid meet')
+
+    const g = svg
+      .append('g')
+      .attr('transform', `translate(${margin.left},${margin.top})`)
+
+    const x = d3
+      .scaleBand()
+      .domain(data.map(d => d3.timeFormat('%a')(d.date)))
+      .range([0, innerWidth])
+      .padding(0.2)
+
+    const y = d3
+      .scaleLinear()
+      .domain([0, d3.max(data, d => d.count)!])
+      .nice()
+      .range([innerHeight, 0])
+
+    g.selectAll('rect')
+      .data(data)
+      .enter()
+      .append('rect')
+      .attr('x', d => x(d3.timeFormat('%a')(d.date))!)
+      .attr('y', d => y(d.count))
+      .attr('width', x.bandwidth())
+      .attr('height', d => innerHeight - y(d.count))
+      .attr('fill', '#3b82f6')
+
+    g.append('g')
+      .attr('transform', `translate(0,${innerHeight})`)
+      .call(d3.axisBottom(x))
+      .selectAll('text')
+      .attr('font-size', 10)
+
+    g.append('g').call(d3.axisLeft(y).ticks(3).tickFormat(d3.format('d')))
+  }
+
+  useEffect(() => {
+    renderChart()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [bugs, size.width])
+
+  return (
+    <div ref={wrapperRef} className="w-full">
+      <svg ref={svgRef} className="w-full h-40 select-none" />
+    </div>
+  )
+}
+
+export default BugForecast

--- a/src/lib/bug-forecast.test.ts
+++ b/src/lib/bug-forecast.test.ts
@@ -1,0 +1,10 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { forecastBugCounts } from './bug-forecast.ts'
+import { bugs } from '../mock/bugs.ts'
+
+test('forecast returns requested number of days', () => {
+  const result = forecastBugCounts(bugs, 5)
+  assert.strictEqual(result.length, 5)
+  result.forEach(point => assert.ok(typeof point.count === 'number'))
+})

--- a/src/lib/bug-forecast.ts
+++ b/src/lib/bug-forecast.ts
@@ -1,0 +1,52 @@
+export interface ForecastPoint {
+  date: Date
+  count: number
+}
+
+import type { Bug } from '../types/bug'
+
+export const forecastBugCounts = (bugs: Bug[], days = 7): ForecastPoint[] => {
+  const floor = (d: Date) =>
+    new Date(d.getFullYear(), d.getMonth(), d.getDate())
+  const counts = new Map<number, number>()
+
+  for (const bug of bugs) {
+    if (!bug.createdAt) continue
+    const ts = floor(new Date(bug.createdAt)).getTime()
+    counts.set(ts, (counts.get(ts) || 0) + 1)
+  }
+
+  const dates = Array.from(counts.keys()).sort((a, b) => a - b)
+  const daily = dates.map(d => counts.get(d) ?? 0)
+  if (daily.length === 0) return []
+
+  const n = daily.length
+  let sumX = 0
+  let sumY = 0
+  let sumXY = 0
+  let sumX2 = 0
+  for (let i = 0; i < n; i++) {
+    const x = i
+    const y = daily[i]
+    sumX += x
+    sumY += y
+    sumXY += x * y
+    sumX2 += x * x
+  }
+  const denom = n * sumX2 - sumX * sumX
+  const slope = denom !== 0 ? (n * sumXY - sumX * sumY) / denom : 0
+  const intercept = n !== 0 ? (sumY - slope * sumX) / n : 0
+
+  const lastDate = new Date(dates[dates.length - 1])
+  const results: ForecastPoint[] = []
+
+  for (let i = 1; i <= days; i++) {
+    const x = n - 1 + i
+    const count = Math.max(0, Math.round(slope * x + intercept))
+    const d = floor(new Date(lastDate))
+    d.setDate(d.getDate() + i)
+    results.push({ date: d, count })
+  }
+
+  return results
+}

--- a/src/routes/Dashboard.tsx
+++ b/src/routes/Dashboard.tsx
@@ -31,6 +31,7 @@ import {
 import { motion } from 'framer-motion'
 import { useEffect, useState } from 'react'
 import BugTrendsChart from '../components/BugTrendsChart'
+import BugForecast from '../components/BugForecast'
 import { useNavigate } from 'react-router-dom'
 import { raised as raisedBase, sunken as sunkenBase } from '../utils/win95'
 
@@ -370,6 +371,7 @@ export default function Dashboard() {
       </div>
 
       <BugTrendsChart bugs={bugs} />
+      <BugForecast bugs={bugs} />
 
       {/* Top row stats */}
       <div className="grid gap-6 md:grid-cols-2 mb-6">


### PR DESCRIPTION
## Summary
- predict future bug counts with forecastBugCounts util
- show a bug forecast bar chart on the dashboard
- document new capability in the README
- test forecastBugCounts logic

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683a356e92e0832a8c6749f34c5315ed