### PR TITLE
Add fortune cookie feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ This is a "bug bounty hackathon" project that ironically has more bugs than it f
 - 🧹 **Automatic Cleanup**: Squashed bugs vanish on their own, only to respawn
 - 🚫 **Comical 404 Page**: Getting lost has never been so entertaining
 - 🌑 **Konami Code Dark Mode**: Enter the secret code for a darker UI
+- 🥠 **Fortune Cookie**: Random words of wisdom on the Bugs page
 
 ### 🎪 The Technology Circus
 

--- a/src/components/FortuneCookie.tsx
+++ b/src/components/FortuneCookie.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react'
+import { raised } from '../utils/win95'
+
+const FORTUNES = [
+  'A bug in time saves nine more bugs.',
+  'Even the smallest bug can lead to big rewards.',
+  'Today is a good day to squash a bug.',
+  'Squashed bugs smell like victory.',
+  'Debugging: because real bugs have feelings too.',
+  'Every bug you find hides two more.',
+]
+
+export default function FortuneCookie() {
+  const [fortune, setFortune] = useState('')
+
+  const randomFortune = () => {
+    const msg = FORTUNES[Math.floor(Math.random() * FORTUNES.length)]
+    setFortune(msg)
+  }
+
+  useEffect(() => {
+    randomFortune()
+  }, [])
+
+  return (
+    <div className={`mt-2 text-center bg-[#C0C0C0] p-2 ${raised}`}>
+      <p className="text-sm">🥠 {fortune}</p>
+      <button
+        onClick={randomFortune}
+        className={`mt-2 px-2 py-1 bg-[#E0E0E0] ${raised} hover:bg-[#D0D0D0]`}
+      >
+        New Fortune
+      </button>
+    </div>
+  )
+}

--- a/src/routes/Bugs.tsx
+++ b/src/routes/Bugs.tsx
@@ -2,6 +2,7 @@ import BugArea from '../components/BugArea'
 import { useBugStore } from '../store'
 import { raised } from '../utils/win95'
 import Meta from '../components/Meta'
+import FortuneCookie from '../components/FortuneCookie'
 
 export default function Bugs() {
   const bugs = useBugStore(s => s.bugs)
@@ -28,6 +29,7 @@ export default function Bugs() {
         <p className="text-center text-sm text-gray-800 py-2">
           Click to squash a bug&nbsp;&amp;&nbsp;earn its bounty 👆
         </p>
+        <FortuneCookie />
       </div>
     </>
   )


### PR DESCRIPTION
## Summary
- display a fortune on the Bugs page
- show new fortunes at the press of a button
- document fortune cookie feature

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683a357c4470832aa90111921185ddcd