### PR TITLE
Add landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ This is a "bug bounty hackathon" project that ironically has more bugs than it f
 - 🧹 **Automatic Cleanup**: Squashed bugs vanish on their own, only to respawn
 - 🚫 **Comical 404 Page**: Getting lost has never been so entertaining
 - 🌑 **Konami Code Dark Mode**: Enter the secret code for a darker UI
+- 🏠 **Landing Page**: A home screen to kick off your bug-squashing adventure
 
 ### 🎪 The Technology Circus
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { Suspense, lazy, useEffect, useState } from 'react'
 import { useKonamiDarkMode } from './hooks/use-konami-dark-mode'
 import { useBugStore } from './store'
 
+const Landing = lazy(() => import('./routes/Landing'))
 const Bugs = lazy(() => import('./routes/Bugs'))
 const Leaderboard = lazy(() => import('./routes/Leaderboard'))
 const UserProfile = lazy(() => import('./routes/UserProfile'))
@@ -37,6 +38,8 @@ function AppContent() {
     switch (location.pathname) {
       case '/':
         return 'Bug Basher'
+      case '/bugs':
+        return 'Bug Arena'
       case '/dashboard':
         return 'Bug Dashboard'
       case '/bounty-leaderboard':
@@ -127,6 +130,12 @@ function AppContent() {
                     to="/"
                     className={`px-4 py-1 ${location.pathname === '/' ? 'bg-[#E0E0E0] font-semibold' : 'hover:bg-[#D0D0D0]'}`}
                   >
+                    🏠 Home
+                  </Link>
+                  <Link
+                    to="/bugs"
+                    className={`px-4 py-1 ${location.pathname === '/bugs' ? 'bg-[#E0E0E0] font-semibold' : 'hover:bg-[#D0D0D0]'}`}
+                  >
                     🐛 Bugs
                   </Link>
                   <Link
@@ -147,7 +156,8 @@ function AppContent() {
                 <div className="p-2 overflow-auto relative z-0 flex-grow flex flex-col">
                   <Suspense fallback={<div className="p-4">Loading...</div>}>
                     <Routes>
-                      <Route path="/" element={<Bugs />} />
+                      <Route path="/" element={<Landing />} />
+                      <Route path="/bugs" element={<Bugs />} />
                       <Route path="/dashboard" element={<Dashboard />} />
                       <Route
                         path="/bounty-leaderboard"

--- a/src/routes/Landing.tsx
+++ b/src/routes/Landing.tsx
@@ -1,0 +1,27 @@
+import { Link } from 'react-router-dom'
+import Meta from '../components/Meta'
+import { raised } from '../utils/win95'
+
+export default function Landing() {
+  return (
+    <>
+      <Meta
+        title="Bug Basher - Welcome"
+        description="Start squashing bugs and earning bounties."
+      />
+      <div className="flex flex-col items-center justify-center gap-6 flex-grow text-center">
+        <h1 className="text-3xl font-bold">Welcome to Bug Basher</h1>
+        <p className="text-lg max-w-md">
+          Join the ultimate bug bounty experience and climb the leaderboard by
+          squashing pesky critters.
+        </p>
+        <Link
+          to="/bugs"
+          className={`px-4 py-2 bg-[#C0C0C0] ${raised} hover:bg-[#A0A0A0]`}
+        >
+          Start Squashing
+        </Link>
+      </div>
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- add a landing page component
- route to the landing page at `/`
- move bug page to `/bugs`
- document landing page in README

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683a359eeb44832aba74ecf3647df8bd