### PR TITLE
Add sign up form

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ This is a "bug bounty hackathon" project that ironically has more bugs than it f
 - 🧹 **Automatic Cleanup**: Squashed bugs vanish on their own, only to respawn
 - 🚫 **Comical 404 Page**: Getting lost has never been so entertaining
 - 🌑 **Konami Code Dark Mode**: Enter the secret code for a darker UI
+- ✍️ **Sign Up Form**: Create your own bug-bashing persona
 
 ### 🎪 The Technology Circus
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ const Dashboard = lazy(() => import('./routes/Dashboard'))
 const NewBug = lazy(() => import('./routes/NewBug'))
 const NotFound = lazy(() => import('./routes/NotFound'))
 const EasterEgg = lazy(() => import('./routes/EasterEgg'))
+const SignUp = lazy(() => import('./routes/SignUp'))
 import { Minus, Square, X as CloseIcon } from 'lucide-react'
 import { raised, windowShadow } from './utils/win95'
 import Taskbar from './components/Taskbar'
@@ -43,6 +44,8 @@ function AppContent() {
         return 'Bug Bounty Leaderboard'
       case '/bug/new':
         return 'File a Bug'
+      case '/sign-up':
+        return 'Sign Up'
       case '/easter-egg':
         return 'Secret Bug Found'
       default:
@@ -141,6 +144,12 @@ function AppContent() {
                   >
                     🏆 Leaderboard
                   </Link>
+                  <Link
+                    to="/sign-up"
+                    className={`px-4 py-1 ${location.pathname === '/sign-up' ? 'bg-[#E0E0E0] font-semibold' : 'hover:bg-[#D0D0D0]'}`}
+                  >
+                    ✍️ Sign Up
+                  </Link>
                 </div>
 
                 {/* Route Content */}
@@ -155,6 +164,7 @@ function AppContent() {
                       />
                       <Route path="/user/:userId" element={<UserProfile />} />
                       <Route path="/bug/new" element={<NewBug />} />
+                      <Route path="/sign-up" element={<SignUp />} />
                       <Route path="/easter-egg" element={<EasterEgg />} />
                       <Route path="*" element={<NotFound />} />
                     </Routes>

--- a/src/routes/SignUp.tsx
+++ b/src/routes/SignUp.tsx
@@ -1,0 +1,115 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Button } from '../components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '../components/ui/card'
+import { Input } from '../components/ui/input'
+import { Label } from '../components/ui/label'
+import { useBugStore } from '../store'
+import { raised as raisedBase, sunken as sunkenBase } from '../utils/win95'
+import Meta from '../components/Meta'
+import ladybugAvatar from '../assets/profile-ladybug.png'
+import beeAvatar from '../assets/profile-bee.png'
+import spiderAvatar from '../assets/spider.png'
+import flyAvatar from '../assets/fly.png'
+import mosquitoAvatar from '../assets/mosquito.png'
+import beetleAvatar from '../assets/brown-beetle.png'
+import antAvatar from '../assets/ant.png'
+import mothAvatar from '../assets/moth.png'
+import cockroachAvatar from '../assets/cockroach.png'
+import caterpillarAvatar from '../assets/caterpillar.png'
+
+export default function SignUp() {
+  const navigate = useNavigate()
+  const [name, setName] = useState('')
+  const [error, setError] = useState('')
+
+  const addUser = useBugStore(s => s.addUser)
+
+  const avatars = [
+    ladybugAvatar,
+    beeAvatar,
+    spiderAvatar,
+    flyAvatar,
+    mosquitoAvatar,
+    beetleAvatar,
+    antAvatar,
+    mothAvatar,
+    cockroachAvatar,
+    caterpillarAvatar,
+  ]
+
+  const createUser = () => {
+    if (!name.trim()) {
+      setError('Please enter a name')
+      return
+    }
+
+    const avatar = avatars[Math.floor(Math.random() * avatars.length)]
+
+    addUser({
+      id: Date.now(),
+      name: name.trim(),
+      avatar,
+      bugs: [],
+      bounty: 0,
+      score: 0,
+      bugsSquashed: [],
+    })
+
+    navigate('/bounty-leaderboard')
+  }
+
+  const raised = `${raisedBase} shadow-sm`
+  const sunken = `${sunkenBase} shadow-inner`
+
+  return (
+    <>
+      <Meta title="Sign Up" description="Create a new Bug Basher account." />
+      <div className="max-w-md mx-auto">
+        <Card className={`bg-[#E0E0E0] ${raised}`}>
+          <CardHeader>
+            <CardTitle className="text-2xl font-bold">Sign Up</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {error && (
+              <div className={`${sunken} bg-red-100 text-red-800 p-2 text-sm`}>
+                {error}
+              </div>
+            )}
+            <div className="space-y-1">
+              <Label htmlFor="name">Your Name</Label>
+              <Input
+                id="name"
+                value={name}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setName(e.target.value)
+                }
+                className={`bg-white ${sunken}`}
+              />
+            </div>
+          </CardContent>
+          <CardFooter className="flex justify-between">
+            <Button
+              className={`${raised} bg-[#C0C0C0] hover:bg-[#A0A0A0] text-black`}
+              onClick={() => navigate('/bounty-leaderboard')}
+            >
+              Cancel
+            </Button>
+            <Button
+              className={`${raised} bg-[#008080] hover:bg-[#006666] text-white`}
+              onClick={createUser}
+            >
+              Create Account
+            </Button>
+          </CardFooter>
+        </Card>
+      </div>
+    </>
+  )
+}

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -64,3 +64,17 @@ test('respawn timer adds bugs when below minimum', () => {
   useBugStore.getState().stopAutomaticSystems()
   timers.reset()
 })
+
+// Test that addUser inserts user and updates activeUserId
+
+test('addUser adds user and sets active user', () => {
+  resetStore()
+
+  const user = { id: 123, name: 'Tester', avatar: '', bugs: [], bounty: 0 }
+
+  useBugStore.getState().addUser(user)
+
+  const users = useBugStore.getState().users
+  assert.ok(users.find(u => u.id === 123))
+  assert.strictEqual(useBugStore.getState().activeUserId, 123)
+})

--- a/src/store.ts
+++ b/src/store.ts
@@ -24,6 +24,11 @@ export const useBugStore = create<StoreState>((set, get) => ({
   activeUserId: 1, // assume first user is the current hacker
   inspectedId: null,
   addBug: bug => set(state => ({ bugs: [...state.bugs, bug] })),
+  addUser: user =>
+    set(state => ({
+      users: [...state.users, user].sort((a, b) => b.bounty - a.bounty),
+      activeUserId: user.id,
+    })),
   inspectBug: id => set({ inspectedId: id }),
   removeBug: id =>
     set(state => ({

--- a/src/types/store-state.ts
+++ b/src/types/store-state.ts
@@ -9,6 +9,7 @@ export interface StoreState {
   inspectBug: (id: string | null) => void
   squashBug: (id: string) => void
   addBug: (bug: Bug) => void
+  addUser: (user: User) => void
   removeBug: (id: string) => void
   startAutomaticSystems: () => void
   stopAutomaticSystems: () => void


### PR DESCRIPTION
## Summary
- add a new SignUp route for creating users
- link SignUp in navigation and router
- allow adding users to the store
- document the new feature in README
- test the new store method

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683a35a92dd0832a9309edd6c18fcd98