### PR TITLE
Move fortune cookie to its own tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This is a "bug bounty hackathon" project that ironically has more bugs than it f
 - 🌦️ **Weather Forecast**: Plan your bug hunts around the faux forecast
 - 🌑 **Konami Code Dark Mode**: Enter the secret code for a darker UI
 - ☕ **Coffee Overflow Bug**: Demo data now includes a caffeinated crash
-- 🥠 **Fortune Cookie**: Random words of wisdom on the Bugs page
+- 🥠 **Fortune Cookie**: Random words of wisdom on its own tab
 - 🧩 **Captcha Protection**: Basic math challenge to keep bots at bay
 - ✍️ **Sign Up Form**: Create your own bug-bashing persona
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ const NotFound = lazy(() => import('./routes/NotFound'))
 const EasterEgg = lazy(() => import('./routes/EasterEgg'))
 const Weather = lazy(() => import('./routes/Weather'))
 const SignUp = lazy(() => import('./routes/SignUp'))
+const Fortune = lazy(() => import('./routes/Fortune'))
 import { Minus, Square, X as CloseIcon } from 'lucide-react'
 import { raised, windowShadow } from './utils/win95'
 import Taskbar from './components/Taskbar'
@@ -51,6 +52,8 @@ function AppContent() {
         return 'Secret Bug Found'
       case '/weather':
         return 'Weather Forecast'
+      case '/fortune':
+        return 'Fortune Cookie'
       default:
         if (location.pathname.startsWith('/user/')) return 'User Profile'
         return 'Page Not Found'
@@ -154,6 +157,12 @@ function AppContent() {
                     🌦️ Weather
                   </Link>
                   <Link
+                    to="/fortune"
+                    className={`px-4 py-1 ${location.pathname === '/fortune' ? 'bg-[#E0E0E0] font-semibold' : 'hover:bg-[#D0D0D0]'}`}
+                  >
+                    🥠 Fortune
+                  </Link>
+                  <Link
                     to="/sign-up"
                     className={`px-4 py-1 ${location.pathname === '/sign-up' ? 'bg-[#E0E0E0] font-semibold' : 'hover:bg-[#D0D0D0]'}`}
                   >
@@ -172,6 +181,7 @@ function AppContent() {
                         element={<Leaderboard />}
                       />
                       <Route path="/weather" element={<Weather />} />
+                      <Route path="/fortune" element={<Fortune />} />
                       <Route path="/user/:userId" element={<UserProfile />} />
                       <Route path="/bug/new" element={<NewBug />} />
                       <Route path="/sign-up" element={<SignUp />} />

--- a/src/routes/Bugs.tsx
+++ b/src/routes/Bugs.tsx
@@ -2,7 +2,6 @@ import BugArea from '../components/BugArea'
 import { useBugStore } from '../store'
 import { raised } from '../utils/win95'
 import Meta from '../components/Meta'
-import FortuneCookie from '../components/FortuneCookie'
 
 export default function Bugs() {
   const bugs = useBugStore(s => s.bugs)
@@ -29,7 +28,6 @@ export default function Bugs() {
         <p className="text-center text-sm text-gray-800 py-2">
           Click to squash a bug&nbsp;&amp;&nbsp;earn its bounty 👆
         </p>
-        <FortuneCookie />
       </div>
     </>
   )

--- a/src/routes/Fortune.tsx
+++ b/src/routes/Fortune.tsx
@@ -1,0 +1,17 @@
+import Meta from '../components/Meta'
+import FortuneCookie from '../components/FortuneCookie'
+
+export default function Fortune() {
+  return (
+    <>
+      <Meta
+        title="Fortune Cookie"
+        description="Get a random bug-themed fortune."
+      />
+      <div className="max-w-md mx-auto">
+        <h1 className="text-2xl font-bold">Fortune Cookie</h1>
+        <FortuneCookie />
+      </div>
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- create `src/routes/Fortune.tsx`
- link new Fortune page in navigation and router
- remove fortune cookie from Bugs page
- note the updated tab location in README

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683a3b0ee8a8832ab31466c34b8c35b0