### PR TITLE
Add unlimited PTO for bug rewards

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This is a "bug bounty hackathon" project that ironically has more bugs than it f
 - 🎬 **Framer Motion**: Animated everything because static websites are for quitters
 - 🖥️ **Windows 95 Taskbar**: Because productivity peaks with a retro clock
 - 🔍 **Search & Filter**: Hunt bugs and leaderboard entries like a pro
-- ⏰ **PTO Rewards**: Earn ridiculous amounts of time off for each bug you squash
+- ⏰ **Unlimited PTO**: Every bug you squash grants infinite time off
 - 🧹 **Automatic Cleanup**: Squashed bugs vanish on their own, only to respawn
 - 🔮 **Bug Forecast**: Peer into tomorrow's infestation with predictive charts
 - 🚫 **Comical 404 Page**: Getting lost has never been so entertaining

--- a/src/components/BugCard.tsx
+++ b/src/components/BugCard.tsx
@@ -77,7 +77,7 @@ export const BugCard: React.FC<BugCardProps> = ({
             +{bug.bounty}
           </span>
           <span className="ml-2 inline-block rounded-full bg-blue-600 px-2 py-1 text-xs font-mono text-white">
-            {bug.pto}h PTO
+            {bug.pto === Infinity ? '∞' : `${bug.pto}h`} PTO
           </span>
           {bug.priority && (
             <span

--- a/src/mock/bugs.ts
+++ b/src/mock/bugs.ts
@@ -14,7 +14,7 @@ export const bugs: Bug[] = [
     description:
       'Safari rage-quits the instant you press "Log In."  It just nopes out.',
     bounty: 200,
-    pto: 8,
+    pto: Infinity,
     active: true,
     createdAt: daysAgo(6),
     priority: 'high',
@@ -25,7 +25,7 @@ export const bugs: Bug[] = [
     description:
       'Loader spins so long we suspect it entered a parallel universe.',
     bounty: 80,
-    pto: 3,
+    pto: Infinity,
     active: true,
     createdAt: daysAgo(6),
     priority: 'medium',
@@ -36,7 +36,7 @@ export const bugs: Bug[] = [
     description:
       'Blasts a full-screen white flash before night-theme.  Vampires displeased.',
     bounty: 50,
-    pto: 2,
+    pto: Infinity,
     active: true,
     createdAt: daysAgo(5),
     priority: 'low',
@@ -47,7 +47,7 @@ export const bugs: Bug[] = [
     description:
       'Sending a single 🐙 turns the whole chat thread into hieroglyphics.',
     bounty: 120,
-    pto: 4,
+    pto: Infinity,
     active: true,
     createdAt: daysAgo(5),
     priority: 'medium',
@@ -58,7 +58,7 @@ export const bugs: Bug[] = [
     description:
       'Page politely scrolls to the top every 42 seconds (Douglas Adams approves).',
     bounty: 70,
-    pto: 2,
+    pto: Infinity,
     active: true,
     createdAt: daysAgo(4),
     priority: 'low',
@@ -69,7 +69,7 @@ export const bugs: Bug[] = [
     description:
       'Disappears the moment DevTools is open, reappears when you glance away.',
     bounty: 150,
-    pto: 6,
+    pto: Infinity,
     active: true,
     createdAt: daysAgo(3),
     priority: 'high',
@@ -79,7 +79,7 @@ export const bugs: Bug[] = [
     title: 'Cache Me Outside',
     description: 'Old avatar refuses to leave—cache is just vibing.',
     bounty: 60,
-    pto: 1,
+    pto: Infinity,
     active: true,
     createdAt: daysAgo(2),
     priority: 'low',
@@ -89,7 +89,7 @@ export const bugs: Bug[] = [
     title: 'CSS Houdini',
     description: 'Button makes a great escape by floating off-screen on hover.',
     bounty: 90,
-    pto: 3,
+    pto: Infinity,
     active: true,
     createdAt: daysAgo(1),
     priority: 'medium',
@@ -100,7 +100,7 @@ export const bugs: Bug[] = [
     description:
       'Modal opens, close button missing… gamers call it a soft-lock.',
     bounty: 110,
-    pto: 4,
+    pto: Infinity,
     active: true,
     createdAt: daysAgo(1),
     priority: 'medium',
@@ -111,7 +111,7 @@ export const bugs: Bug[] = [
     description:
       'Users receive a push saying "…" at 3 AM.  Spooky season, every season.',
     bounty: 130,
-    pto: 5,
+    pto: Infinity,
     active: true,
     createdAt: daysAgo(0),
     priority: 'high',
@@ -122,7 +122,7 @@ export const bugs: Bug[] = [
     description:
       'Repeated coffee orders slowly chew through memory until the app crashes.',
     bounty: 75,
-    pto: 2,
+    pto: Infinity,
     active: true,
     createdAt: daysAgo(0),
     priority: 'medium',

--- a/src/store.ts
+++ b/src/store.ts
@@ -126,7 +126,7 @@ export const useBugStore = create<StoreState>((set, get) => ({
             title: template.title,
             description: template.description,
             bounty,
-            pto: Math.floor(Math.random() * 8) + 1,
+            pto: Infinity,
             active: true,
             priority,
             createdAt: new Date().toISOString(),

--- a/src/types/bug.ts
+++ b/src/types/bug.ts
@@ -3,7 +3,7 @@ export interface Bug {
   title: string
   description: string
   bounty: number
-  /** Paid time off earned for squashing this bug (hours) */
+  /** Paid time off earned for squashing this bug (hours, Infinity = unlimited) */
   pto: number
   active: boolean
   priority?: 'high' | 'medium' | 'low'


### PR DESCRIPTION
## Summary
- give every bug infinite PTO
- spawn new bugs with unlimited PTO
- display infinity symbol for PTO on BugCard
- document unlimited PTO in the readme

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683a41edab7c832aa99a36096166c759