### PR TITLE
Add job description page

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ This is a "bug bounty hackathon" project that ironically has more bugs than it f
 - 🥠 **Fortune Cookie**: Random words of wisdom on its own tab
 - 🧩 **Captcha Protection**: Basic math challenge to keep bots at bay
 - ✍️ **Sign Up Form**: Create your own bug-bashing persona
+- 📄 **Job Description Page**: Read about the prestigious Bug Basher role
 
 ### 🎪 The Technology Circus
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ const EasterEgg = lazy(() => import('./routes/EasterEgg'))
 const Weather = lazy(() => import('./routes/Weather'))
 const SignUp = lazy(() => import('./routes/SignUp'))
 const Fortune = lazy(() => import('./routes/Fortune'))
+const JobDescription = lazy(() => import('./routes/JobDescription'))
 import { Minus, Square, X as CloseIcon } from 'lucide-react'
 import { raised, windowShadow } from './utils/win95'
 import Taskbar from './components/Taskbar'
@@ -54,6 +55,8 @@ function AppContent() {
         return 'Weather Forecast'
       case '/fortune':
         return 'Fortune Cookie'
+      case '/job-description':
+        return 'Job Description'
       default:
         if (location.pathname.startsWith('/user/')) return 'User Profile'
         return 'Page Not Found'
@@ -168,6 +171,12 @@ function AppContent() {
                   >
                     ✍️ Sign Up
                   </Link>
+                  <Link
+                    to="/job-description"
+                    className={`px-4 py-1 ${location.pathname === '/job-description' ? 'bg-[#E0E0E0] font-semibold' : 'hover:bg-[#D0D0D0]'}`}
+                  >
+                    📄 Job Description
+                  </Link>
                 </div>
 
                 {/* Route Content */}
@@ -185,6 +194,10 @@ function AppContent() {
                       <Route path="/user/:userId" element={<UserProfile />} />
                       <Route path="/bug/new" element={<NewBug />} />
                       <Route path="/sign-up" element={<SignUp />} />
+                      <Route
+                        path="/job-description"
+                        element={<JobDescription />}
+                      />
                       <Route path="/easter-egg" element={<EasterEgg />} />
                       <Route path="*" element={<NotFound />} />
                     </Routes>

--- a/src/routes/JobDescription.tsx
+++ b/src/routes/JobDescription.tsx
@@ -1,0 +1,24 @@
+import Meta from '../components/Meta'
+
+export default function JobDescription() {
+  return (
+    <>
+      <Meta
+        title="Job Description"
+        description="Learn about the prestigious Bug Basher position."
+      />
+      <div className="space-y-4">
+        <h1 className="text-2xl font-bold">Bug Basher Role</h1>
+        <p>
+          We're looking for fearless developers to squash imaginary bugs in our
+          retro-inspired arena. Duties include clicking frantically, sipping
+          copious coffee, and laughing at our codebase.
+        </p>
+        <p>
+          Benefits include bragging rights, unlimited virtual PTO, and the
+          occasional congratulatory meme.
+        </p>
+      </div>
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- add JobDescription page to share role details
- link it in the navigation and router
- document new page in the README

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683b32455d8c832ab27012a7c1ff20c4