### PR TITLE
Add Web Audio effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ This is a "bug bounty hackathon" project that ironically has more bugs than it f
 - 🌑 **Konami Code Dark Mode**: Enter the secret code for a darker UI
 - ☕ **Coffee Overflow Bug**: Demo data now includes a caffeinated crash
 - 🥠 **Fortune Cookie**: Random words of wisdom on its own tab
+- 🔊 **Web Audio Effects**: Ambient drones and bug-squash beeps, plus a talking fortune cookie
 - 🧩 **Captcha Protection**: Basic math challenge to keep bots at bay
 - ✍️ **Sign Up Form**: Create your own bug-bashing persona
 - 📄 **Job Description Page**: Read about the prestigious Bug Basher role

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import {
 } from 'react-router-dom'
 import { Suspense, lazy, useEffect, useState } from 'react'
 import { useKonamiDarkMode } from './hooks/use-konami-dark-mode'
+import { useAudio } from './hooks/use-audio'
 import { useBugStore } from './store'
 
 const Bugs = lazy(() => import('./routes/Bugs'))
@@ -23,6 +24,7 @@ const JobDescription = lazy(() => import('./routes/JobDescription'))
 import { Minus, Square, X as CloseIcon } from 'lucide-react'
 import { raised, windowShadow } from './utils/win95'
 import Taskbar from './components/Taskbar'
+import { AudioContext } from './contexts/AudioContext'
 
 function AppContent() {
   const location = useLocation()
@@ -220,7 +222,9 @@ function AppContent() {
 export default function App() {
   return (
     <BrowserRouter>
-      <AppContent />
+      <AudioContext.Provider value={useAudio()}>
+        <AppContent />
+      </AudioContext.Provider>
     </BrowserRouter>
   )
 }

--- a/src/components/BugCard.tsx
+++ b/src/components/BugCard.tsx
@@ -4,6 +4,7 @@ import { useBugStore, priorityModel } from '../store'
 import clsx from 'clsx'
 import { getBugImage } from '../utils/utils'
 import { predictPriorityProbability } from '../lib/bug-priority-ml.ts'
+import { useAudioContext } from '../contexts/AudioContext'
 
 export const BugCard: React.FC<BugCardProps> = ({
   bug,
@@ -11,6 +12,7 @@ export const BugCard: React.FC<BugCardProps> = ({
   modal = false,
 }) => {
   const squashBug = useBugStore(s => s.squashBug)
+  const audio = useAudioContext()
   const bugImage = getBugImage(bug.id)
   const highProb =
     priorityModel && bug.bounty
@@ -32,7 +34,10 @@ export const BugCard: React.FC<BugCardProps> = ({
       )}
       onClick={e => {
         e.stopPropagation()
-        if (bug.active) squashBug(bug.id)
+        if (bug.active) {
+          squashBug(bug.id)
+          audio?.playBugSquash?.()
+        }
       }}
       initial={{ opacity: 0, scale: 0.9 }}
       animate={{ opacity: 1, scale: 1 }}

--- a/src/components/FortuneCookie.tsx
+++ b/src/components/FortuneCookie.tsx
@@ -18,6 +18,13 @@ export default function FortuneCookie() {
     setFortune(msg)
   }
 
+  const speakFortune = () => {
+    if (fortune) {
+      const utter = new SpeechSynthesisUtterance(fortune)
+      window.speechSynthesis.speak(utter)
+    }
+  }
+
   useEffect(() => {
     randomFortune()
   }, [])
@@ -25,12 +32,20 @@ export default function FortuneCookie() {
   return (
     <div className={`mt-2 text-center bg-[#C0C0C0] p-2 ${raised}`}>
       <p className="text-sm">🥠 {fortune}</p>
-      <button
-        onClick={randomFortune}
-        className={`mt-2 px-2 py-1 bg-[#E0E0E0] ${raised} hover:bg-[#D0D0D0]`}
-      >
-        New Fortune
-      </button>
+      <div className="flex justify-center gap-2 mt-2">
+        <button
+          onClick={randomFortune}
+          className={`px-2 py-1 bg-[#E0E0E0] ${raised} hover:bg-[#D0D0D0]`}
+        >
+          New Fortune
+        </button>
+        <button
+          onClick={speakFortune}
+          className={`px-2 py-1 bg-[#E0E0E0] ${raised} hover:bg-[#D0D0D0]`}
+        >
+          🔈 Read Aloud
+        </button>
+      </div>
     </div>
   )
 }

--- a/src/contexts/AudioContext.tsx
+++ b/src/contexts/AudioContext.tsx
@@ -1,0 +1,8 @@
+import { createContext, useContext } from 'react'
+
+export interface AudioApi {
+  playBugSquash: () => void
+}
+
+export const AudioContext = createContext<AudioApi | null>(null)
+export const useAudioContext = () => useContext(AudioContext)

--- a/src/hooks/use-audio.ts
+++ b/src/hooks/use-audio.ts
@@ -1,0 +1,55 @@
+import { useEffect, useRef } from 'react'
+import { useBugStore } from '../store'
+
+export function useAudio() {
+  const ctxRef = useRef<AudioContext>()
+  const ambientGain = useRef<GainNode>()
+
+  useEffect(() => {
+    const typedWindow = window as typeof window & {
+      webkitAudioContext?: typeof AudioContext
+    }
+    const Ctor = window.AudioContext || typedWindow.webkitAudioContext
+    const ctx = new Ctor()
+    const gain = ctx.createGain()
+    gain.gain.value = 0.05
+    gain.connect(ctx.destination)
+
+    const osc = ctx.createOscillator()
+    osc.type = 'sine'
+    osc.frequency.value = 220
+    osc.connect(gain)
+    osc.start()
+
+    ctxRef.current = ctx
+    ambientGain.current = gain
+
+    return () => {
+      osc.stop()
+      ctx.close()
+    }
+  }, [])
+
+  const playBugSquash = () => {
+    const ctx = ctxRef.current
+    if (!ctx) return
+    const o = ctx.createOscillator()
+    o.type = 'square'
+    o.frequency.value = 440
+    const g = ctx.createGain()
+    g.gain.value = 0.2
+    o.connect(g)
+    g.connect(ctx.destination)
+    o.start()
+    o.stop(ctx.currentTime + 0.1)
+  }
+
+  const activeCount = useBugStore(s => s.bugs.filter(b => b.active).length)
+  useEffect(() => {
+    if (ambientGain.current) {
+      ambientGain.current.gain.value = 0.02 + 0.01 * Math.min(activeCount, 10)
+    }
+  }, [activeCount])
+
+  return { playBugSquash }
+}


### PR DESCRIPTION
## Summary
- provide a simple Web Audio hook and context
- play a beep when a bug is squashed
- add ambient audio that grows with bug count
- allow Fortune Cookie fortunes to be spoken
- document audio features

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683d3de8da0c832abc076a16b5cc63e7