### PR TITLE
Add audio feedback when shooting bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ This is a "bug bounty hackathon" project that ironically has more bugs than it f
 - 🌑 **Konami Code Dark Mode**: Enter the secret code for a darker UI
 - ☕ **Coffee Overflow Bug**: Demo data now includes a caffeinated crash
 - 🥠 **Fortune Cookie**: Random words of wisdom on its own tab
-- 🔊 **Web Audio Effects**: Ambient drones and bug-squash beeps, plus a talking fortune cookie
+- 🔊 **Web Audio Effects**: Ambient drones and bug-squash beeps (even when shooting bugs on the canvas), plus a talking fortune cookie
 - 🧩 **Captcha Protection**: Basic math challenge to keep bots at bay
 - ✍️ **Sign Up Form**: Create your own bug-bashing persona
 - 📄 **Job Description Page**: Read about the prestigious Bug Basher role

--- a/src/components/BugArea.tsx
+++ b/src/components/BugArea.tsx
@@ -4,6 +4,7 @@ import type { BugAreaProps } from '../types/bug-area-props'
 import BugCrawler from './BugCrawler'
 import AimCursor from './AimCursor'
 import { useBugStore } from '../store'
+import { useAudioContext } from '../contexts/AudioContext'
 
 /** Evenly spreads bugs, then shuffles and jitters them for an organic layout. */
 
@@ -33,6 +34,7 @@ const BugArea: React.FC<BugAreaProps> = ({ bugs }) => {
   }, [aim])
 
   /* ---------- modal helpers ---------- */
+  const audio = useAudioContext()
   const squashBug = useBugStore(s => s.squashBug)
   const inspectedId = useBugStore(s => s.inspectedId)
   const inspectedIdRef = useRef(inspectedId)
@@ -45,6 +47,7 @@ const BugArea: React.FC<BugAreaProps> = ({ bugs }) => {
     // If a modal is open, squash that bug and close the modal.
     if (inspectedIdRef.current) {
       squashBug(inspectedIdRef.current)
+      audio?.playBugSquash?.()
       return
     }
 
@@ -62,12 +65,13 @@ const BugArea: React.FC<BugAreaProps> = ({ bugs }) => {
         const idAttr = node.getAttribute?.('data-bug-id')
         if (idAttr) {
           node.click() // triggers onClick in BugCrawler (opens modal or squashes)
+          audio?.playBugSquash?.()
           return
         }
         node = node.parentElement
       }
     }
-  }, [squashBug])
+  }, [squashBug, audio])
 
   /* ---------- keyboard press state ---------- */
   const pressedRef = useRef({


### PR DESCRIPTION
## Summary
- play the squash sound when firing at a bug on the canvas
- document new audio feedback in the README

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683d477255e4832aa708c2039379c752