### PR TITLE
Add start menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ This is a "bug bounty hackathon" project that ironically has more bugs than it f
 - 🎨 **Tailwind CSS**: 47KB of utility classes to style 3 buttons
 - 🎬 **Framer Motion**: Animated everything because static websites are for quitters
 - 🖥️ **Windows 95 Taskbar**: Because productivity peaks with a retro clock
+- 📂 **Start Menu**: Authentic start menu for quick navigation
 - 🔍 **Search & Filter**: Hunt bugs and leaderboard entries like a pro
 - ⏰ **PTO Rewards**: Earn ridiculous amounts of time off for each bug you squash
 - 🧹 **Automatic Cleanup**: Squashed bugs vanish on their own, only to respawn
@@ -180,6 +181,7 @@ See [docs/NAMING_CONVENTIONS.md](docs/NAMING_CONVENTIONS.md) for the complete gu
 - `AimCursor.tsx`: Mouse cursor replacement nobody asked for
 - `BugTrendsChart.tsx`: Gradient-filled line chart with zoomable timelines
 - `Taskbar.tsx`: Windows 95 clock for peak nostalgia
+- `StartMenu.tsx`: Clickable start button menu
 - `NotFound.tsx`: A 404 page with jokes for when routing fails
 
 **📊 Dashboard Extravaganza:**

--- a/src/components/StartMenu.tsx
+++ b/src/components/StartMenu.tsx
@@ -1,0 +1,43 @@
+import { Link } from 'react-router-dom'
+import { raised, sunken, windowShadow } from '../utils/win95'
+
+export default function StartMenu({ onClose }: { onClose: () => void }) {
+  const itemClass = `block px-2 py-1 ${raised} bg-[#E0E0E0] hover:${sunken}`
+  return (
+    <div
+      className={`absolute bottom-8 left-0 w-40 p-2 bg-[#C0C0C0] ${raised} ${windowShadow} text-sm`}
+    >
+      <ul className="space-y-1">
+        <li>
+          <Link to="/" onClick={onClose} className={itemClass}>
+            🐛 Bugs
+          </Link>
+        </li>
+        <li>
+          <Link to="/dashboard" onClick={onClose} className={itemClass}>
+            📊 Dashboard
+          </Link>
+        </li>
+        <li>
+          <Link
+            to="/bounty-leaderboard"
+            onClick={onClose}
+            className={itemClass}
+          >
+            🏆 Leaderboard
+          </Link>
+        </li>
+        <li>
+          <Link to="/weather" onClick={onClose} className={itemClass}>
+            🌦️ Weather
+          </Link>
+        </li>
+        <li>
+          <Link to="/sign-up" onClick={onClose} className={itemClass}>
+            ✍️ Sign Up
+          </Link>
+        </li>
+      </ul>
+    </div>
+  )
+}

--- a/src/components/Taskbar.tsx
+++ b/src/components/Taskbar.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { raised, sunken } from '../utils/win95'
+import StartMenu from './StartMenu'
 import type { TaskbarProps } from '../types/taskbar-props'
 
 const getTime = () =>
@@ -11,6 +12,7 @@ export default function Taskbar({
   onToggle,
 }: TaskbarProps) {
   const [time, setTime] = useState(getTime())
+  const [open, setOpen] = useState(false)
 
   useEffect(() => {
     const id = setInterval(() => setTime(getTime()), 1000)
@@ -22,6 +24,7 @@ export default function Taskbar({
       className={`h-8 bg-[#C0C0C0] flex items-center px-1 justify-between ${sunken}`}
     >
       <button
+        onClick={() => setOpen(v => !v)}
         className={`flex items-center h-6 px-2 gap-1 bg-[#C0C0C0] ${raised} active:${sunken}`}
       >
         <span className="w-3 h-3 bg-[#000080]" />
@@ -40,6 +43,12 @@ export default function Taskbar({
       <div className={`h-6 px-2 bg-[#C0C0C0] ${raised} font-mono text-sm`}>
         {time}
       </div>
+      {open && (
+        <>
+          <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />
+          <StartMenu onClose={() => setOpen(false)} />
+        </>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- introduce `<StartMenu>` with quick links
- display StartMenu from the Taskbar
- document the new feature in README

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683f3d93f084832a97f450f1221c8ab9