### PR TITLE
Rewrite naming conventions with humor

### DIFF
--- a/docs/NAMING_CONVENTIONS.md
+++ b/docs/NAMING_CONVENTIONS.md
@@ -1,19 +1,19 @@
 # Naming Conventions
 
-This project follows a few simple rules to keep file and variable names predictable.
+Welcome to our comedic guide on how to name things without losing your sanity. Follow these rules and your code will look sharp enough to cut through the boring stuff.
 
 ## Folders
 
-- Lower-case names, hyphenated when a folder name contains multiple words.
+- Keep folder names in lowercase because hitting the SHIFT key is a workout. Use hyphens when the name has more words than your lunch order.
 
 ## Files
 
-- React components use `PascalCase.tsx` and export a default component with the same name.
-- Non-component utilities and modules use lower-case names and may include hyphens, e.g. `utils.ts`, `badge-variants.ts`.
-- Test files mirror the module they cover and use the `.test.ts` extension.
+- React components strut around in `PascalCase.tsx` and each one exports itself as the star of the show.
+- Non-component utilities and modules prefer a laid-back lowercase vibe. Hyphens are welcome when they feel rebellious, e.g. `utils.ts`, `badge-variants.ts`.
+- Test files faithfully mirror the module they're judging and end with a dramatic `.test.ts`.
 
 ## Code
 
-- Variables and functions are written in `camelCase`.
-- Constants that represent configuration values are written in `UPPER_SNAKE_CASE`.
-- Types and interfaces use `PascalCase`.
+- Variables and functions whisper politely in `camelCase`.
+- Configuration constants shout from the rooftops in `UPPER_SNAKE_CASE`.
+- Types and interfaces keep it classy with `PascalCase`.


### PR DESCRIPTION
## Summary
- add comedic flair to docs/NAMING_CONVENTIONS.md

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683f5372c640832aad7dc7fbd10bea52