### PR TITLE
Add unit tests for pages and components

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ npm run lint     # Lint code
 npm run format   # Format code
 ```
 
+The test suite now includes coverage for every page and component.
+
 ### 🎭 Getting Started (Abandon Hope, All Ye Who Enter Here)
 
 **Prerequisites:**

--- a/png-loader.js
+++ b/png-loader.js
@@ -1,8 +1,34 @@
+import fs from 'node:fs/promises'
+import ts from 'typescript'
+
 export async function resolve(specifier, context, defaultResolve) {
   if (specifier.endsWith('.png')) {
     return {
       url: new URL(specifier, context.parentURL).href,
       shortCircuit: true,
+    }
+  }
+  if (specifier.endsWith('.tsx')) {
+    return {
+      url: new URL(specifier, context.parentURL).href,
+      shortCircuit: true,
+    }
+  }
+  if (specifier.endsWith('.tsx')) {
+    return {
+      url: new URL(specifier, context.parentURL).href,
+      shortCircuit: true,
+    }
+  }
+  if (!specifier.startsWith('node:') && !specifier.endsWith('.ts')) {
+    for (const ext of ['.ts', '.tsx']) {
+      try {
+        const url = new URL(specifier + ext, context.parentURL)
+        await fs.access(url)
+        return { url: url.href, shortCircuit: true }
+      } catch {
+        // continue
+      }
     }
   }
   return defaultResolve(specifier, context, defaultResolve)
@@ -15,6 +41,18 @@ export async function load(url, context, defaultLoad) {
       source: `export default ${JSON.stringify(url)};`,
       shortCircuit: true,
     }
+  }
+  if (url.endsWith('.tsx')) {
+    const source = await fs.readFile(new URL(url), 'utf8')
+    const result = ts.transpileModule(source, {
+      compilerOptions: {
+        module: ts.ModuleKind.ESNext,
+        jsx: ts.JsxEmit.ReactJSX,
+        target: ts.ScriptTarget.ES2020,
+      },
+      fileName: url,
+    })
+    return { format: 'module', source: result.outputText, shortCircuit: true }
   }
   return defaultLoad(url, context, defaultLoad)
 }

--- a/src/components/components.test.ts
+++ b/src/components/components.test.ts
@@ -1,0 +1,99 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+
+import AimCursor from './AimCursor.tsx'
+import BugArea from './BugArea.tsx'
+import { BugCard } from './BugCard.tsx'
+import BugCrawler from './BugCrawler.tsx'
+import BugForecast from './BugForecast.tsx'
+import BugTrendsChart from './BugTrendsChart.tsx'
+import Captcha from './Captcha.tsx'
+import FortuneCookie from './FortuneCookie.tsx'
+import Meta from './Meta.tsx'
+import StartMenu from './StartMenu.tsx'
+import Taskbar from './Taskbar.tsx'
+import { bugs } from '../mock/bugs.ts'
+
+const sampleBug = bugs[0]
+
+const h = React.createElement
+
+const wrap = (element: React.ReactElement) => renderToStaticMarkup(element)
+
+test('AimCursor renders', () => {
+  const html = wrap(h(AimCursor, { x: 5, y: 5 }))
+  assert.ok(html.includes('pointer-events-none'))
+})
+
+test('BugArea renders', () => {
+  const html = wrap(h(BugArea, { bugs: [sampleBug] }))
+  assert.ok(html.includes('cursor-none'))
+})
+
+test('BugCard renders', () => {
+  const html = wrap(h(BugCard, { bug: sampleBug }))
+  assert.ok(html.includes(sampleBug.title))
+})
+
+test('BugCrawler renders', () => {
+  const html = wrap(
+    h(BugCrawler, {
+      bug: sampleBug,
+      x: 0,
+      y: 0,
+      containerWidth: 100,
+      containerHeight: 100,
+    })
+  )
+  assert.ok(html.includes('img'))
+})
+
+test('BugForecast renders', () => {
+  const html = wrap(h(BugForecast, { bugs: [sampleBug] }))
+  assert.ok(html.includes('svg'))
+})
+
+test('BugTrendsChart renders', () => {
+  const html = wrap(h(BugTrendsChart, { bugs: [sampleBug] }))
+  assert.ok(html.includes('svg'))
+})
+
+test('Captcha renders', () => {
+  const html = wrap(h(Captcha, { onChange: () => {} }))
+  assert.ok(html.includes('What is'))
+})
+
+test('FortuneCookie renders', () => {
+  const html = wrap(h(FortuneCookie))
+  assert.ok(html.includes('New Fortune'))
+})
+
+test('Meta renders', () => {
+  const html = wrap(h(Meta, { title: 'Test title', description: 'Test desc' }))
+  assert.strictEqual(html, '')
+})
+
+test('StartMenu renders', () => {
+  const html = renderToStaticMarkup(
+    h(MemoryRouter, null, h(StartMenu, { onClose: () => {} }))
+  )
+  assert.ok(html.includes('Bugs'))
+})
+
+test('Taskbar renders', () => {
+  const html = renderToStaticMarkup(
+    h(
+      MemoryRouter,
+      null,
+      h(Taskbar, {
+        windowTitle: 'Window',
+        minimized: false,
+        onToggle: () => {},
+      })
+    )
+  )
+  assert.ok(html.includes('Start'))
+})

--- a/src/components/ui/ui-components.test.ts
+++ b/src/components/ui/ui-components.test.ts
@@ -1,0 +1,122 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { Badge } from './badge.tsx'
+import { Button } from './button.tsx'
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+  CardFooter,
+} from './card.tsx'
+import { Input } from './input.tsx'
+import { Label } from './label.tsx'
+import {
+  NavigationMenu,
+  NavigationMenuList,
+  NavigationMenuItem,
+  NavigationMenuTrigger,
+  NavigationMenuContent,
+} from './navigation-menu.tsx'
+import { Progress } from './progress.tsx'
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from './select.tsx'
+import { Tabs, TabsList, TabsTrigger, TabsContent } from './tabs.tsx'
+import { Textarea } from './textarea.tsx'
+
+const h = React.createElement
+const wrap = (el: React.ReactElement) => renderToStaticMarkup(el)
+
+test('Badge renders', () => {
+  const html = wrap(h(Badge, null, 'Badge'))
+  assert.ok(html.includes('Badge'))
+})
+
+test('Button renders', () => {
+  const html = wrap(h(Button, null, 'Click'))
+  assert.ok(html.includes('Click'))
+})
+
+test('Card renders', () => {
+  const html = wrap(
+    h(
+      Card,
+      null,
+      h(CardHeader, null, h(CardTitle, null, 'Title')),
+      h(CardContent, null, 'Body'),
+      h(CardFooter, null, 'Footer')
+    )
+  )
+  assert.ok(html.includes('Title'))
+})
+
+test('Input renders', () => {
+  const html = wrap(h(Input, { value: 'x', onChange: () => {} }))
+  assert.ok(html.includes('value="x"'))
+})
+
+test('Label renders', () => {
+  const html = wrap(h(Label, { htmlFor: 'i' }, 'Label'))
+  assert.ok(html.includes('Label'))
+})
+
+test('NavigationMenu renders', () => {
+  const html = wrap(
+    h(
+      NavigationMenu,
+      null,
+      h(
+        NavigationMenuList,
+        null,
+        h(
+          NavigationMenuItem,
+          null,
+          h(NavigationMenuTrigger, null, 'Menu'),
+          h(NavigationMenuContent, null, 'Content')
+        )
+      )
+    )
+  )
+  assert.ok(html.includes('Menu'))
+})
+
+test('Progress renders', () => {
+  const html = wrap(h(Progress, { value: 50 }))
+  assert.ok(html.includes('translateX'))
+})
+
+test('Select renders', () => {
+  const html = wrap(
+    h(
+      Select,
+      { value: 'a', onValueChange: () => {} },
+      h(SelectTrigger, null, h(SelectValue, { placeholder: 'sel' })),
+      h(SelectContent, null, h(SelectItem, { value: 'a' }, 'A'))
+    )
+  )
+  assert.ok(html.includes('relative'))
+})
+
+test('Tabs renders', () => {
+  const html = wrap(
+    h(
+      Tabs,
+      { defaultValue: 't1' },
+      h(TabsList, null, h(TabsTrigger, { value: 't1' }, 'T1')),
+      h(TabsContent, { value: 't1' }, 'C1')
+    )
+  )
+  assert.ok(html.includes('C1'))
+})
+
+test('Textarea renders', () => {
+  const html = wrap(h(Textarea))
+  assert.ok(html.includes('textarea'))
+})

--- a/src/routes/pages.test.ts
+++ b/src/routes/pages.test.ts
@@ -1,0 +1,87 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+
+import Bugs from './Bugs.tsx'
+import Dashboard from './Dashboard.tsx'
+import EasterEgg from './EasterEgg.tsx'
+import Fortune from './Fortune.tsx'
+import JobDescription from './JobDescription.tsx'
+import Leaderboard from './Leaderboard.tsx'
+import NewBug from './NewBug.tsx'
+import NotFound from './NotFound.tsx'
+import SignUp from './SignUp.tsx'
+import UserProfile from './UserProfile.tsx'
+import Weather from './Weather.tsx'
+
+const h = React.createElement
+
+const wrap = (element: React.ReactElement, path = '/') =>
+  renderToStaticMarkup(h(MemoryRouter, { initialEntries: [path] }, element))
+
+test('Bugs page renders', () => {
+  const html = wrap(h(Bugs))
+  assert.ok(html.includes('squash a bug'))
+})
+
+test('Dashboard page renders', () => {
+  const html = wrap(h(Dashboard))
+  assert.ok(html.includes('Bug Bounty Dashboard'))
+})
+
+test('EasterEgg page renders', () => {
+  const html = wrap(h(EasterEgg))
+  assert.ok(html.includes('Easter Egg'))
+})
+
+test('Fortune page renders', () => {
+  const html = wrap(h(Fortune))
+  assert.ok(html.includes('Fortune Cookie'))
+})
+
+test('JobDescription page renders', () => {
+  const html = wrap(h(JobDescription))
+  assert.ok(html.includes('Bug Basher Role'))
+})
+
+test('Leaderboard page renders', () => {
+  const html = wrap(h(Leaderboard))
+  assert.ok(html.includes('Search'))
+})
+
+test('NewBug page renders', () => {
+  const html = wrap(h(NewBug))
+  assert.ok(html.includes('File a New Bug'))
+})
+
+test('NotFound page renders', () => {
+  const html = wrap(h(NotFound))
+  assert.ok(html.includes('Page Not Found'))
+})
+
+test('SignUp page renders', () => {
+  const html = wrap(h(SignUp))
+  assert.ok(html.includes('Sign Up'))
+})
+
+test('UserProfile page renders', () => {
+  const html = renderToStaticMarkup(
+    h(
+      MemoryRouter,
+      { initialEntries: ['/user/1'] },
+      h(
+        Routes,
+        null,
+        h(Route, { path: '/user/:userId', element: h(UserProfile) })
+      )
+    )
+  )
+  assert.ok(html.length > 0)
+})
+
+test('Weather page renders', () => {
+  const html = wrap(h(Weather))
+  assert.ok(html.includes('Weather Forecast'))
+})


### PR DESCRIPTION
## Summary
- extend png-loader to transpile TSX files for node tests
- add unit tests covering all pages and components
- document new tests in README

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683f538631ec832abff28ea5911a5064