### PR TITLE
Add coverage reporting workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,10 @@ jobs:
 
       - name: Run tests with coverage
         run: |
-          NODE_OPTIONS='--experimental-test-coverage' npm test 2>&1 | tee coverage.txt
+          node --experimental-transform-types \
+            --loader ./png-loader.js \
+            --experimental-test-coverage \
+            --test 2>&1 | tee coverage.txt
 
       - name: Upload coverage summary
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,46 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests with coverage
+        run: |
+          NODE_OPTIONS='--experimental-test-coverage' npm test 2>&1 | tee coverage.txt
+
+      - name: Upload coverage summary
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage.txt
+
+      - name: Comment coverage
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const coverage = fs.readFileSync('coverage.txt', 'utf8');
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `## Test Coverage\n\n\`\`\`\n${coverage}\n\`\`\``
+            });

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ npm run format   # Format code
 ```
 
 The test suite now includes coverage for every page and component.
+Coverage results are uploaded as an artifact in the Test workflow.
 
 ### 🎭 Getting Started (Abandon Hope, All Ye Who Enter Here)
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ npm run format   # Format code
 
 The test suite now includes coverage for every page and component.
 Coverage results are uploaded as an artifact in the Test workflow.
+The workflow also comments a short coverage summary on pull requests.
 
 ### 🎭 Getting Started (Abandon Hope, All Ye Who Enter Here)
 


### PR DESCRIPTION
## Summary
- add GitHub action to run tests with coverage
- upload coverage as an artifact and post summary in PRs
- document coverage artifact in README

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683f58403328832ab9e849b62c17e2e8