### PR TITLE
Fix lint warnings by extracting helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ This is a "bug bounty hackathon" project that ironically has more bugs than it f
 - ⏰ **PTO Rewards**: Earn ridiculous amounts of time off for each bug you squash
 - 🧹 **Automatic Cleanup**: Squashed bugs vanish on their own, only to respawn
 - 🔮 **Bug Forecast**: Peer into tomorrow's infestation with predictive charts
+- 🧮 **Dashboard Helpers**: Bounty totals and date formatting now live in a
+  shared module
 - 🚫 **Comical 404 Page**: Getting lost has never been so entertaining
 - 🌦️ **Weather Forecast**: Plan your bug hunts around the faux forecast
 - 🌑 **Konami Code Dark Mode**: Enter the secret code for a darker UI

--- a/src/routes/Dashboard.tsx
+++ b/src/routes/Dashboard.tsx
@@ -34,18 +34,7 @@ import BugTrendsChart from '../components/BugTrendsChart'
 import BugForecast from '../components/BugForecast'
 import { useNavigate } from 'react-router-dom'
 import { raised as raisedBase, sunken as sunkenBase } from '../utils/win95'
-
-// Helper function to calculate total bounty
-const calculateTotalBounty = (bugs: Bug[]): number =>
-  bugs.reduce((total, bug) => total + bug.bounty, 0)
-
-// Helper function to format date
-const formatDate = (date: Date): string =>
-  new Intl.DateTimeFormat('en-US', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  }).format(date)
+import { calculateTotalBounty, formatDate } from '../utils/dashboard'
 
 // Simple chart component for bug priority distribution
 const PriorityChart = ({ bugs }: { bugs: Bug[] }) => {

--- a/src/routes/dashboard-helpers.test.ts
+++ b/src/routes/dashboard-helpers.test.ts
@@ -1,0 +1,19 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { calculateTotalBounty, formatDate } from '../utils/dashboard'
+
+test('calculateTotalBounty sums bug bounties', () => {
+  const bugs: Array<{ bounty: number }> = [
+    { bounty: 100 },
+    { bounty: 200 },
+    { bounty: 50 },
+  ]
+  assert.strictEqual(calculateTotalBounty(bugs), 350)
+})
+
+test('formatDate outputs a readable string', () => {
+  const date = new Date('2024-05-18T12:34:56Z')
+  const result = formatDate(date)
+  assert.ok(/\d{4}/.test(result))
+  assert.ok(result.length > 0)
+})

--- a/src/utils/dashboard.ts
+++ b/src/utils/dashboard.ts
@@ -1,0 +1,9 @@
+export const calculateTotalBounty = (bugs: Array<{ bounty: number }>): number =>
+  bugs.reduce((total, bug) => total + bug.bounty, 0)
+
+export const formatDate = (date: Date): string =>
+  new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  }).format(date)


### PR DESCRIPTION
## Summary
- extract `calculateTotalBounty` and `formatDate` into `src/utils/dashboard.ts`
- update Dashboard to import these helpers
- update tests and README

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683f5830b428832a86055934997b8427