### PR TITLE
Improve leaderboard tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ See [docs/NAMING_CONVENTIONS.md](docs/NAMING_CONVENTIONS.md) for the complete gu
 - Score persistence not yet implemented
 - Displays achievements for playing alone
 - Searchable table to find your imaginary rivals
+- Helper functions exported for easier testing
 
 ### 🎭 Performance Notes
 

--- a/src/routes/Leaderboard.tsx
+++ b/src/routes/Leaderboard.tsx
@@ -3,9 +3,10 @@ import { Link } from 'react-router-dom'
 import { useBugStore } from '../store'
 import Meta from '../components/Meta'
 import { Input } from '../components/ui/input'
+import type { Bug } from '../types/bug.ts'
 
 /** Map bounty → tier name */
-const levelFromBounty = (bounty: number): string => {
+export const levelFromBounty = (bounty: number): string => {
   if (bounty >= 6000) return 'Platinum'
   if (bounty >= 4000) return 'Gold'
   if (bounty >= 2000) return 'Silver'
@@ -13,14 +14,84 @@ const levelFromBounty = (bounty: number): string => {
 }
 
 /** Rank level tiers so they can be numerically compared */
-const levelTier = (bounty: number): number => {
+export const levelTier = (bounty: number): number => {
   if (bounty >= 6000) return 4
   if (bounty >= 4000) return 3
   if (bounty >= 2000) return 2
   return 1
 }
 
-type SortKey = 'rank' | 'name' | 'bugs' | 'bounty' | 'efficiency' | 'level'
+export type SortKey =
+  | 'rank'
+  | 'name'
+  | 'bugs'
+  | 'bounty'
+  | 'efficiency'
+  | 'level'
+
+export interface SortableUser {
+  id: number
+  name: string
+  avatar?: string
+  bugs: Bug[] | number[]
+  bounty?: number
+}
+
+export const sortUsers = (
+  users: SortableUser[],
+  sortKey: SortKey,
+  ascending: boolean
+): SortableUser[] => {
+  const list = [...users]
+
+  list.sort((a, b) => {
+    const bugCountA =
+      (Array.isArray(a.bugs) ? a.bugs.length : (a.bugs ?? 0)) ?? 0
+    const bugCountB =
+      (Array.isArray(b.bugs) ? b.bugs.length : (b.bugs ?? 0)) ?? 0
+    const bountyA = a.bounty ?? 0
+    const bountyB = b.bounty ?? 0
+    const efficiencyA = bugCountA > 0 ? bountyA / bugCountA : 0
+    const efficiencyB = bugCountB > 0 ? bountyB / bugCountB : 0
+
+    let valA: number | string = 0
+    let valB: number | string = 0
+
+    switch (sortKey) {
+      case 'rank':
+        // Rank is the default bounty-desc ordering
+        valA = bountyA
+        valB = bountyB
+        break
+      case 'name':
+        valA = a.name.toLowerCase()
+        valB = b.name.toLowerCase()
+        break
+      case 'bugs':
+        valA = bugCountA
+        valB = bugCountB
+        break
+      case 'bounty':
+        valA = bountyA
+        valB = bountyB
+        break
+      case 'efficiency':
+        valA = efficiencyA
+        valB = efficiencyB
+        break
+      case 'level':
+        valA = levelTier(bountyA)
+        valB = levelTier(bountyB)
+        break
+    }
+
+    if (valA < valB) return ascending ? -1 : 1
+    if (valA > valB) return ascending ? 1 : -1
+    return 0
+  })
+
+  return list
+}
 
 export default function Leaderboard() {
   const users = useBugStore(s => s.users)
@@ -49,57 +120,10 @@ export default function Leaderboard() {
   }, [users, query])
 
   /** Users sorted according to selected column */
-  const sortedUsers = React.useMemo(() => {
-    const list = [...filteredUsers]
-
-    list.sort((a, b) => {
-      const bugCountA =
-        (Array.isArray(a.bugs) ? a.bugs.length : (a.bugs ?? 0)) ?? 0
-      const bugCountB =
-        (Array.isArray(b.bugs) ? b.bugs.length : (b.bugs ?? 0)) ?? 0
-      const bountyA = a.bounty ?? 0
-      const bountyB = b.bounty ?? 0
-      const efficiencyA = bugCountA > 0 ? bountyA / bugCountA : 0
-      const efficiencyB = bugCountB > 0 ? bountyB / bugCountB : 0
-
-      let valA: number | string = 0
-      let valB: number | string = 0
-
-      switch (sortKey) {
-        case 'rank':
-          // Rank is the default bounty-desc ordering
-          valA = bountyA
-          valB = bountyB
-          break
-        case 'name':
-          valA = a.name.toLowerCase()
-          valB = b.name.toLowerCase()
-          break
-        case 'bugs':
-          valA = bugCountA
-          valB = bugCountB
-          break
-        case 'bounty':
-          valA = bountyA
-          valB = bountyB
-          break
-        case 'efficiency':
-          valA = efficiencyA
-          valB = efficiencyB
-          break
-        case 'level':
-          valA = levelTier(bountyA)
-          valB = levelTier(bountyB)
-          break
-      }
-
-      if (valA < valB) return ascending ? -1 : 1
-      if (valA > valB) return ascending ? 1 : -1
-      return 0
-    })
-
-    return list
-  }, [filteredUsers, sortKey, ascending])
+  const sortedUsers = React.useMemo(
+    () => sortUsers(filteredUsers, sortKey, ascending),
+    [filteredUsers, sortKey, ascending]
+  )
 
   /** Helper to render sort arrows */
   const sortArrow = (key: SortKey) =>

--- a/src/routes/leaderboard.test.ts
+++ b/src/routes/leaderboard.test.ts
@@ -1,0 +1,79 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import Leaderboard, {
+  levelFromBounty,
+  levelTier,
+  sortUsers,
+} from './Leaderboard.tsx'
+import { MemoryRouter } from 'react-router-dom'
+import { users as mockUsers } from '../mock/users.ts'
+import { useBugStore } from '../store'
+import { bugs as mockBugs } from '../mock/bugs.ts'
+
+const h = React.createElement
+
+// Basic users for sorting tests
+const sampleUsers = [
+  { id: 1, name: 'Bravo', bugs: new Array(2), bounty: 3000 },
+  { id: 2, name: 'Alpha', bugs: new Array(1), bounty: 5000 },
+  { id: 3, name: 'Charlie', bugs: new Array(4), bounty: 1000 },
+]
+
+const resetStore = () => {
+  useBugStore.setState({
+    bugs: structuredClone(mockBugs),
+    users: structuredClone(mockUsers),
+    activeUserId: 1,
+    inspectedId: null,
+  })
+}
+
+test('level helpers map bounty to correct tier', () => {
+  assert.strictEqual(levelFromBounty(7000), 'Platinum')
+  assert.strictEqual(levelFromBounty(4500), 'Gold')
+  assert.strictEqual(levelFromBounty(2500), 'Silver')
+  assert.strictEqual(levelFromBounty(100), 'Bronze')
+
+  assert.strictEqual(levelTier(7000), 4)
+  assert.strictEqual(levelTier(4500), 3)
+  assert.strictEqual(levelTier(2500), 2)
+  assert.strictEqual(levelTier(100), 1)
+})
+
+test('sortUsers orders users by various keys', () => {
+  const byName = sortUsers(sampleUsers, 'name', true)
+  assert.deepStrictEqual(
+    byName.map(u => u.id),
+    [2, 1, 3]
+  )
+
+  const byBounty = sortUsers(sampleUsers, 'bounty', false)
+  assert.deepStrictEqual(
+    byBounty.map(u => u.id),
+    [2, 1, 3]
+  )
+
+  const byEfficiency = sortUsers(sampleUsers, 'efficiency', false)
+  // efficiencies: Bravo 1500, Alpha 5000, Charlie 250
+  assert.deepStrictEqual(
+    byEfficiency.map(u => u.id),
+    [2, 1, 3]
+  )
+
+  const byLevel = sortUsers(sampleUsers, 'level', false)
+  assert.deepStrictEqual(
+    byLevel.map(u => u.id),
+    [2, 1, 3]
+  )
+})
+
+test('Leaderboard component renders user rows', () => {
+  resetStore()
+  const html = renderToStaticMarkup(h(MemoryRouter, null, h(Leaderboard)))
+  const first = mockUsers[0]
+  assert.ok(html.includes(first.name))
+  assert.ok(html.includes('Gold'))
+})


### PR DESCRIPTION
## Summary
- expose helper utilities from Leaderboard for easier testing
- cover sorting helpers and rendering in leaderboard tests
- document helper exports in README

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683f6d057d70832a8155a3bd77685b58