### PR TITLE
Fix CI to update existing test coverage comments instead of creating new ones

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,13 +85,13 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
             });
-            
+
             const existingComment = comments.data.find(comment => 
               comment.body.startsWith('## Test Coverage')
             );
-            
+
             const body = `## Test Coverage\n\n${table}`;
-            
+
             if (existingComment) {
               await github.rest.issues.updateComment({
                 comment_id: existingComment.id,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,9 +80,30 @@ jobs:
             } else {
               table = `\`\`\`\n${coverage}\n\`\`\``;
             }
-            github.rest.issues.createComment({
+            const comments = await github.rest.issues.listComments({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `## Test Coverage\n\n${table}`
             });
+            
+            const existingComment = comments.data.find(comment => 
+              comment.body.startsWith('## Test Coverage')
+            );
+            
+            const body = `## Test Coverage\n\n${table}`;
+            
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                comment_id: existingComment.id,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: body
+              });
+            }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # 🐞 Bug Bounty Hackathon: Where Dreams Go to Debug
 
+<!-- Testing CI comment update functionality -->
+
 <!-- The Badge Wall of Shame: Because Nothing Says "Professional" Like 20+ Meaningless Icons -->
 <div align="center">
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # 🐞 Bug Bounty Hackathon: Where Dreams Go to Debug
 
-<!-- Testing CI comment update functionality -->
-
 <!-- The Badge Wall of Shame: Because Nothing Says "Professional" Like 20+ Meaningless Icons -->
 <div align="center">
 


### PR DESCRIPTION
# Fix CI to update existing test coverage comments instead of creating new ones

## Summary

Modified the GitHub Actions test workflow to update existing test coverage PR comments instead of creating new ones on each CI run. This prevents comment spam and keeps test coverage information in a single, updated location.

**Key Changes:**
- Added logic to list existing PR comments using `github.rest.issues.listComments()`
- Implemented comment detection by searching for comments starting with "## Test Coverage"
- Added conditional logic to update existing comments via `github.rest.issues.updateComment()` or create new ones if none exist
- Maintained backward compatibility - first run still creates a comment, subsequent runs update it

## Review & Testing Checklist for Human

- [ ] **End-to-end testing**: Create a test PR and make multiple commits to verify that the first CI run creates a test coverage comment and subsequent runs update the same comment instead of creating new ones
- [ ] **Comment identification logic**: Verify that the `startsWith('## Test Coverage')` logic correctly identifies test coverage comments and doesn't match unintended comments
- [ ] **GitHub API permissions**: Confirm that the existing `pull-requests: write` permission is sufficient for both creating and updating comments
- [ ] **Error handling**: Test edge cases like API failures or malformed comments to ensure the workflow doesn't break entirely

**Recommended Test Plan:**
1. Create a test PR from this branch
2. Make an initial commit to trigger CI and observe the first test coverage comment creation
3. Make a second commit to the same PR and verify the existing comment gets updated with new test results
4. Check that no duplicate test coverage comments are created

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    subgraph "GitHub Actions Workflow"
        A["test.yml"]:::major-edit
        B["Comment coverage step"]:::major-edit
    end
    
    subgraph "GitHub API Calls"
        C["listComments()"]:::major-edit
        D["updateComment()"]:::major-edit
        E["createComment()"]:::context
    end
    
    subgraph "PR Comments"
        F["Existing Test Coverage Comment"]:::context
        G["New Test Coverage Comment"]:::context
    end
    
    A --> B
    B --> C
    C --> D
    C --> E
    D --> F
    E --> G
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit
        L3["Context/No Edit"]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- This change addresses the issue where CI runs would keep appending new test coverage comments to PRs instead of updating a single comment
- The workflow already has the necessary `pull-requests: write` permission for both creating and updating comments
- The comment identification uses a simple string prefix match which should be robust for the current comment format
- No changes to test execution logic - only the comment posting behavior is modified

**Link to Devin run:** https://app.devin.ai/sessions/250a3dfb9b2d45629c27c43bee1b0bf0  
**Requested by:** @davidyen1124