### PR TITLE
Add Win95 desktop window manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ This is a "bug bounty hackathon" project that ironically has more bugs than it f
 - 🎬 **Framer Motion**: Animated everything because static websites are for quitters
 - 🖥️ **Windows 95 Taskbar**: Because productivity peaks with a retro clock
 - 📂 **Start Menu**: Authentic start menu for quick navigation
+- 🖱️ **Desktop Shortcuts**: Double-clickable icons summon each app like it's 1995
+- 🪟 **Window Shenanigans**: Drag, resize, minimize, maximize, and restore like a pro
 - 🔍 **Search & Filter**: Hunt bugs and leaderboard entries like a pro
 - ⏰ **PTO Rewards**: Earn ridiculous amounts of time off for each bug you squash
 - 🧹 **Automatic Cleanup**: Squashed bugs vanish on their own, only to respawn

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,13 @@
-import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom'
-import { Suspense, lazy, useEffect, useState } from 'react'
+import {
+  BrowserRouter,
+  Routes,
+  Route,
+  useLocation,
+  useNavigate,
+} from 'react-router-dom'
+import { Suspense, lazy, useEffect, useState, useRef, useCallback } from 'react'
+import type { PointerEvent as ReactPointerEvent } from 'react'
+import { Minus, Square, X as CloseIcon } from 'lucide-react'
 import { useKonamiDarkMode } from './hooks/use-konami-dark-mode'
 import { useAudio } from './hooks/use-audio'
 import { useBugStore } from './store'
@@ -15,25 +23,418 @@ const Weather = lazy(() => import('./routes/Weather'))
 const SignUp = lazy(() => import('./routes/SignUp'))
 const Fortune = lazy(() => import('./routes/Fortune'))
 const JobDescription = lazy(() => import('./routes/JobDescription'))
-import { Minus, Square, X as CloseIcon } from 'lucide-react'
+
 import Taskbar from './components/Taskbar'
 import { AudioContext } from './contexts/AudioContext'
 import Window from './components/win95/Window'
 import TitleBar from './components/win95/TitleBar'
 import TabLink from './components/win95/TabLink'
 import Win95Button from './components/win95/Button'
+import DesktopIcon from './components/win95/DesktopIcon'
+
+type DesktopShortcut = {
+  id: string
+  label: string
+  icon: string
+  path: string
+}
+
+const DESKTOP_SHORTCUTS: DesktopShortcut[] = [
+  { id: 'bugs', label: 'Bug Basher', icon: '🐛', path: '/' },
+  { id: 'dashboard', label: 'Dashboard', icon: '📊', path: '/dashboard' },
+  {
+    id: 'leaderboard',
+    label: 'Leaderboard',
+    icon: '🏆',
+    path: '/bounty-leaderboard',
+  },
+  { id: 'weather', label: 'Weather', icon: '🌦️', path: '/weather' },
+  { id: 'fortune', label: 'Fortune', icon: '🥠', path: '/fortune' },
+  { id: 'sign-up', label: 'Sign Up', icon: '✍️', path: '/sign-up' },
+  {
+    id: 'job-description',
+    label: 'Job Description',
+    icon: '📄',
+    path: '/job-description',
+  },
+]
+
+const DEFAULT_WINDOW_POSITION = { x: 48, y: 48 }
+const DEFAULT_WINDOW_SIZE = { width: 960, height: 620 }
+const MIN_WINDOW_SIZE = { width: 560, height: 380 }
+
+type ResizeDirection =
+  | 'left'
+  | 'right'
+  | 'top'
+  | 'bottom'
+  | 'top-left'
+  | 'top-right'
+  | 'bottom-left'
+  | 'bottom-right'
+
+type ResizeState = {
+  direction: ResizeDirection
+  startX: number
+  startY: number
+  startWidth: number
+  startHeight: number
+  startLeft: number
+  startTop: number
+  desktopWidth: number
+  desktopHeight: number
+}
+
+type DragState = {
+  offsetX: number
+  offsetY: number
+}
+
+const clamp = (value: number, min: number, max: number) => {
+  if (max < min) return min
+  return Math.min(Math.max(value, min), max)
+}
+
 function AppContent() {
   const location = useLocation()
+  const navigate = useNavigate()
   const { startAutomaticSystems, stopAutomaticSystems } = useBugStore()
   const [minimized, setMinimized] = useState(false)
   const [maximized, setMaximized] = useState(false)
   const [hidden, setHidden] = useState(false)
+  const [selectedIcon, setSelectedIcon] = useState<string | null>(null)
+  const [windowPosition, setWindowPosition] = useState(() => ({
+    ...DEFAULT_WINDOW_POSITION,
+  }))
+  const [windowSize, setWindowSize] = useState(() => ({
+    ...DEFAULT_WINDOW_SIZE,
+  }))
+  const desktopRef = useRef<HTMLDivElement | null>(null)
+  const windowPositionRef = useRef(windowPosition)
+  const windowSizeRef = useRef(windowSize)
+  const previousBoundsRef = useRef({
+    position: { ...DEFAULT_WINDOW_POSITION },
+    size: { ...DEFAULT_WINDOW_SIZE },
+  })
+  const dragState = useRef<DragState | null>(null)
+  const resizeState = useRef<ResizeState | null>(null)
+  const dragCleanupRef = useRef<(() => void) | null>(null)
+  const resizeCleanupRef = useRef<(() => void) | null>(null)
+
   useKonamiDarkMode()
 
   useEffect(() => {
     startAutomaticSystems()
     return () => stopAutomaticSystems()
   }, [startAutomaticSystems, stopAutomaticSystems])
+
+  useEffect(() => {
+    windowPositionRef.current = windowPosition
+  }, [windowPosition])
+
+  useEffect(() => {
+    windowSizeRef.current = windowSize
+  }, [windowSize])
+
+  useEffect(() => {
+    const desktop = desktopRef.current
+    if (!desktop) return
+    const rect = desktop.getBoundingClientRect()
+    const currentSize = windowSizeRef.current
+    const currentPos = windowPositionRef.current
+
+    const nextWidth = clamp(
+      currentSize.width,
+      MIN_WINDOW_SIZE.width,
+      rect.width
+    )
+    const nextHeight = clamp(
+      currentSize.height,
+      MIN_WINDOW_SIZE.height,
+      rect.height
+    )
+    const maxX = Math.max(0, rect.width - nextWidth)
+    const maxY = Math.max(0, rect.height - nextHeight)
+    const nextX = clamp(currentPos.x, 0, maxX)
+    const nextY = clamp(currentPos.y, 0, maxY)
+
+    if (nextWidth !== currentSize.width || nextHeight !== currentSize.height) {
+      windowSizeRef.current = { width: nextWidth, height: nextHeight }
+      setWindowSize({ width: nextWidth, height: nextHeight })
+    }
+    if (nextX !== currentPos.x || nextY !== currentPos.y) {
+      windowPositionRef.current = { x: nextX, y: nextY }
+      setWindowPosition({ x: nextX, y: nextY })
+    }
+  }, [])
+
+  useEffect(() => {
+    const handleResize = () => {
+      const desktop = desktopRef.current
+      if (!desktop) return
+      const rect = desktop.getBoundingClientRect()
+
+      if (maximized) {
+        const stored = previousBoundsRef.current
+        const nextWidth = clamp(
+          stored.size.width,
+          MIN_WINDOW_SIZE.width,
+          rect.width
+        )
+        const nextHeight = clamp(
+          stored.size.height,
+          MIN_WINDOW_SIZE.height,
+          rect.height
+        )
+        const maxX = Math.max(0, rect.width - nextWidth)
+        const maxY = Math.max(0, rect.height - nextHeight)
+        const nextX = clamp(stored.position.x, 0, maxX)
+        const nextY = clamp(stored.position.y, 0, maxY)
+        previousBoundsRef.current = {
+          position: { x: nextX, y: nextY },
+          size: { width: nextWidth, height: nextHeight },
+        }
+        return
+      }
+
+      const currentSize = windowSizeRef.current
+      const currentPos = windowPositionRef.current
+
+      const nextWidth = clamp(
+        currentSize.width,
+        MIN_WINDOW_SIZE.width,
+        rect.width
+      )
+      const nextHeight = clamp(
+        currentSize.height,
+        MIN_WINDOW_SIZE.height,
+        rect.height
+      )
+      const maxX = Math.max(0, rect.width - nextWidth)
+      const maxY = Math.max(0, rect.height - nextHeight)
+      const nextX = clamp(currentPos.x, 0, maxX)
+      const nextY = clamp(currentPos.y, 0, maxY)
+
+      if (
+        nextWidth !== currentSize.width ||
+        nextHeight !== currentSize.height
+      ) {
+        windowSizeRef.current = { width: nextWidth, height: nextHeight }
+        setWindowSize({ width: nextWidth, height: nextHeight })
+      }
+      if (nextX !== currentPos.x || nextY !== currentPos.y) {
+        windowPositionRef.current = { x: nextX, y: nextY }
+        setWindowPosition({ x: nextX, y: nextY })
+      }
+    }
+
+    window.addEventListener('resize', handleResize)
+    return () => window.removeEventListener('resize', handleResize)
+  }, [maximized])
+
+  useEffect(
+    () => () => {
+      dragCleanupRef.current?.()
+      resizeCleanupRef.current?.()
+    },
+    []
+  )
+
+  const showWindow = useCallback(() => {
+    setHidden(false)
+    setMinimized(false)
+  }, [])
+
+  const handleToggleMaximize = useCallback(() => {
+    setMaximized(previous => {
+      if (previous) {
+        const { position, size } = previousBoundsRef.current
+        const restoredPosition = { ...position }
+        const restoredSize = { ...size }
+        windowPositionRef.current = restoredPosition
+        windowSizeRef.current = restoredSize
+        setWindowPosition(restoredPosition)
+        setWindowSize(restoredSize)
+        return false
+      }
+      previousBoundsRef.current = {
+        position: { ...windowPositionRef.current },
+        size: { ...windowSizeRef.current },
+      }
+      return true
+    })
+  }, [])
+
+  const handleTitleBarPointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (event.button !== 0 || maximized) return
+      const desktop = desktopRef.current
+      if (!desktop) return
+      event.preventDefault()
+      event.stopPropagation()
+      setSelectedIcon(null)
+      setMinimized(false)
+
+      const rect = desktop.getBoundingClientRect()
+      dragState.current = {
+        offsetX: event.clientX - rect.left - windowPositionRef.current.x,
+        offsetY: event.clientY - rect.top - windowPositionRef.current.y,
+      }
+
+      dragCleanupRef.current?.()
+
+      const handleMove = (moveEvent: PointerEvent) => {
+        const state = dragState.current
+        if (!state) return
+        const desktopRect = desktop.getBoundingClientRect()
+        const { width, height } = windowSizeRef.current
+        const rawX = moveEvent.clientX - desktopRect.left - state.offsetX
+        const rawY = moveEvent.clientY - desktopRect.top - state.offsetY
+        const maxX = Math.max(0, desktopRect.width - width)
+        const maxY = Math.max(0, desktopRect.height - height)
+        const nextX = clamp(rawX, 0, maxX)
+        const nextY = clamp(rawY, 0, maxY)
+        if (
+          nextX !== windowPositionRef.current.x ||
+          nextY !== windowPositionRef.current.y
+        ) {
+          windowPositionRef.current = { x: nextX, y: nextY }
+          setWindowPosition({ x: nextX, y: nextY })
+        }
+      }
+
+      const handlePointerUp = () => {
+        dragCleanupRef.current?.()
+        dragCleanupRef.current = null
+        dragState.current = null
+      }
+
+      document.addEventListener('pointermove', handleMove)
+      document.addEventListener('pointerup', handlePointerUp)
+      dragCleanupRef.current = () => {
+        document.removeEventListener('pointermove', handleMove)
+        document.removeEventListener('pointerup', handlePointerUp)
+      }
+    },
+    [maximized]
+  )
+
+  const handleResizeStart = useCallback(
+    (direction: ResizeDirection, event: ReactPointerEvent<HTMLDivElement>) => {
+      if (event.button !== 0 || maximized) return
+      const desktop = desktopRef.current
+      if (!desktop) return
+      event.preventDefault()
+      event.stopPropagation()
+
+      const rect = desktop.getBoundingClientRect()
+      resizeState.current = {
+        direction,
+        startX: event.clientX,
+        startY: event.clientY,
+        startWidth: windowSizeRef.current.width,
+        startHeight: windowSizeRef.current.height,
+        startLeft: windowPositionRef.current.x,
+        startTop: windowPositionRef.current.y,
+        desktopWidth: rect.width,
+        desktopHeight: rect.height,
+      }
+
+      resizeCleanupRef.current?.()
+
+      const handleMove = (moveEvent: PointerEvent) => {
+        const state = resizeState.current
+        if (!state) return
+        const deltaX = moveEvent.clientX - state.startX
+        const deltaY = moveEvent.clientY - state.startY
+
+        const prevPos = windowPositionRef.current
+        const prevSize = windowSizeRef.current
+
+        let nextLeft = prevPos.x
+        let nextTop = prevPos.y
+        let nextWidth = prevSize.width
+        let nextHeight = prevSize.height
+
+        const isLeft = state.direction.includes('left')
+        const isRight = state.direction.includes('right')
+        const isTop = state.direction.includes('top')
+        const isBottom = state.direction.includes('bottom')
+
+        if (isRight) {
+          const maxWidth = state.desktopWidth - state.startLeft
+          nextWidth = clamp(
+            state.startWidth + deltaX,
+            MIN_WINDOW_SIZE.width,
+            maxWidth
+          )
+        }
+
+        if (isBottom) {
+          const maxHeight = state.desktopHeight - state.startTop
+          nextHeight = clamp(
+            state.startHeight + deltaY,
+            MIN_WINDOW_SIZE.height,
+            maxHeight
+          )
+        }
+
+        if (isLeft) {
+          const rawLeft = state.startLeft + deltaX
+          const maxLeft =
+            state.startLeft + state.startWidth - MIN_WINDOW_SIZE.width
+          nextLeft = clamp(rawLeft, 0, maxLeft)
+          const maxWidth = state.desktopWidth - nextLeft
+          nextWidth = clamp(
+            state.startWidth + (state.startLeft - nextLeft),
+            MIN_WINDOW_SIZE.width,
+            maxWidth
+          )
+        }
+
+        if (isTop) {
+          const rawTop = state.startTop + deltaY
+          const maxTop =
+            state.startTop + state.startHeight - MIN_WINDOW_SIZE.height
+          nextTop = clamp(rawTop, 0, maxTop)
+          const maxHeight = state.desktopHeight - nextTop
+          nextHeight = clamp(
+            state.startHeight + (state.startTop - nextTop),
+            MIN_WINDOW_SIZE.height,
+            maxHeight
+          )
+        }
+
+        const maxX = Math.max(0, state.desktopWidth - nextWidth)
+        const maxY = Math.max(0, state.desktopHeight - nextHeight)
+        nextLeft = clamp(nextLeft, 0, maxX)
+        nextTop = clamp(nextTop, 0, maxY)
+
+        if (nextLeft !== prevPos.x || nextTop !== prevPos.y) {
+          windowPositionRef.current = { x: nextLeft, y: nextTop }
+          setWindowPosition({ x: nextLeft, y: nextTop })
+        }
+        if (nextWidth !== prevSize.width || nextHeight !== prevSize.height) {
+          windowSizeRef.current = { width: nextWidth, height: nextHeight }
+          setWindowSize({ width: nextWidth, height: nextHeight })
+        }
+      }
+
+      const handlePointerUp = () => {
+        resizeCleanupRef.current?.()
+        resizeCleanupRef.current = null
+        resizeState.current = null
+      }
+
+      document.addEventListener('pointermove', handleMove)
+      document.addEventListener('pointerup', handlePointerUp)
+      resizeCleanupRef.current = () => {
+        document.removeEventListener('pointermove', handleMove)
+        document.removeEventListener('pointerup', handlePointerUp)
+      }
+    },
+    [maximized]
+  )
 
   const getWindowTitle = () => {
     switch (location.pathname) {
@@ -61,33 +462,158 @@ function AppContent() {
     }
   }
 
-  if (hidden) {
-    return (
-      <div className="min-h-screen bg-[#008080] p-4 font-['MS_Sans_Serif','Tahoma',sans-serif] flex flex-col">
-        <div className="flex-grow flex items-center justify-center">
-          <Win95Button onClick={() => setHidden(false)}>
-            Reopen Window
-          </Win95Button>
-        </div>
-        <Taskbar
-          windowTitle={getWindowTitle()}
-          minimized
-          onToggle={() => setHidden(false)}
+  const windowTitle = getWindowTitle()
+
+  const resizeHandles = maximized
+    ? null
+    : [
+        {
+          direction: 'top' as ResizeDirection,
+          style: {
+            top: 0,
+            left: '50%',
+            width: '40%',
+            height: 8,
+            transform: 'translate(-50%, -50%)',
+            cursor: 'n-resize',
+          },
+        },
+        {
+          direction: 'bottom' as ResizeDirection,
+          style: {
+            bottom: 0,
+            left: '50%',
+            width: '40%',
+            height: 8,
+            transform: 'translate(-50%, 50%)',
+            cursor: 's-resize',
+          },
+        },
+        {
+          direction: 'left' as ResizeDirection,
+          style: {
+            top: '50%',
+            left: 0,
+            width: 8,
+            height: '40%',
+            transform: 'translate(-50%, -50%)',
+            cursor: 'w-resize',
+          },
+        },
+        {
+          direction: 'right' as ResizeDirection,
+          style: {
+            top: '50%',
+            right: 0,
+            width: 8,
+            height: '40%',
+            transform: 'translate(50%, -50%)',
+            cursor: 'e-resize',
+          },
+        },
+        {
+          direction: 'top-left' as ResizeDirection,
+          style: {
+            top: 0,
+            left: 0,
+            width: 12,
+            height: 12,
+            transform: 'translate(-50%, -50%)',
+            cursor: 'nw-resize',
+          },
+        },
+        {
+          direction: 'top-right' as ResizeDirection,
+          style: {
+            top: 0,
+            right: 0,
+            width: 12,
+            height: 12,
+            transform: 'translate(50%, -50%)',
+            cursor: 'ne-resize',
+          },
+        },
+        {
+          direction: 'bottom-left' as ResizeDirection,
+          style: {
+            bottom: 0,
+            left: 0,
+            width: 12,
+            height: 12,
+            transform: 'translate(-50%, 50%)',
+            cursor: 'sw-resize',
+          },
+        },
+        {
+          direction: 'bottom-right' as ResizeDirection,
+          style: {
+            bottom: 0,
+            right: 0,
+            width: 12,
+            height: 12,
+            transform: 'translate(50%, 50%)',
+            cursor: 'se-resize',
+          },
+        },
+      ].map(({ direction, style }) => (
+        <div
+          key={direction}
+          className="absolute z-30"
+          style={{ ...style, touchAction: 'none' }}
+          aria-hidden
+          onPointerDown={event => handleResizeStart(direction, event)}
         />
-      </div>
-    )
-  }
+      ))
 
   return (
-    <div className="min-h-screen bg-[#008080] p-4 font-['MS_Sans_Serif','Tahoma',sans-serif] flex flex-col">
-      <div className="flex-grow flex">
-        {!minimized && (
+    <div className="min-h-screen bg-[#008080] font-['MS_Sans_Serif','Tahoma',sans-serif] flex flex-col">
+      <div
+        ref={desktopRef}
+        className="relative flex-1 p-4"
+        onClick={() => setSelectedIcon(null)}
+      >
+        <div
+          className="relative z-10 flex flex-col gap-4"
+          aria-label="Desktop shortcuts"
+        >
+          {DESKTOP_SHORTCUTS.map(shortcut => (
+            <DesktopIcon
+              key={shortcut.id}
+              icon={shortcut.icon}
+              label={shortcut.label}
+              selected={selectedIcon === shortcut.id}
+              onSelect={() => setSelectedIcon(shortcut.id)}
+              onOpen={() => {
+                setSelectedIcon(shortcut.id)
+                showWindow()
+                navigate(shortcut.path)
+              }}
+            />
+          ))}
+        </div>
+        {!hidden && !minimized && (
           <div
-            className={`mx-auto w-full flex-grow flex ${maximized ? '' : 'max-w-7xl'}`}
+            className="absolute z-20"
+            style={
+              maximized
+                ? { inset: 0 }
+                : {
+                    top: windowPosition.y,
+                    left: windowPosition.x,
+                    width: windowSize.width,
+                    height: windowSize.height,
+                    minWidth: MIN_WINDOW_SIZE.width,
+                    minHeight: MIN_WINDOW_SIZE.height,
+                  }
+            }
+            onPointerDown={() => setSelectedIcon(null)}
           >
-            <Window>
+            <Window className="h-full">
               <TitleBar
-                title={getWindowTitle()}
+                title={windowTitle}
+                onPointerDown={handleTitleBarPointerDown}
+                onDoubleClick={handleToggleMaximize}
+                active={!minimized}
                 controls={
                   <div className="flex gap-px">
                     {[
@@ -99,18 +625,27 @@ function AppContent() {
                       {
                         Icon: Square,
                         label: maximized ? 'Restore' : 'Maximize',
-                        onClick: () => setMaximized(v => !v),
+                        onClick: handleToggleMaximize,
                       },
                       {
                         Icon: CloseIcon,
                         label: 'Close',
-                        onClick: () => setHidden(true),
+                        onClick: () => {
+                          if (maximized) {
+                            handleToggleMaximize()
+                          }
+                          setHidden(true)
+                          setMinimized(false)
+                        },
                       },
                     ].map(({ Icon, label, onClick }) => (
                       <Win95Button
                         key={label}
                         aria-label={label}
-                        onClick={onClick}
+                        onClick={event => {
+                          event.stopPropagation()
+                          onClick()
+                        }}
                         className="h-6 w-6 p-0"
                       >
                         <Icon className="h-3 w-3 text-black" />
@@ -119,8 +654,8 @@ function AppContent() {
                   </div>
                 }
               />
-              <div className="bg-[#E0E0E0] p-3 flex flex-col flex-grow">
-                <div className="mb-4 bg-[#C0C0C0] flex gap-1 p-1 sticky top-0 z-10">
+              <div className="bg-[#E0E0E0] flex flex-col flex-1 overflow-hidden p-3">
+                <div className="mb-4 flex gap-1 bg-[#C0C0C0] p-1 sticky top-0 z-10">
                   <TabLink to="/" active={location.pathname === '/'}>
                     🐛 Bugs
                   </TabLink>
@@ -161,7 +696,7 @@ function AppContent() {
                     📄 Job Description
                   </TabLink>
                 </div>
-                <div className="p-2 overflow-auto relative z-0 flex-grow flex flex-col">
+                <div className="relative z-0 flex flex-1 flex-col overflow-auto p-2">
                   <Suspense fallback={<div className="p-4">Loading...</div>}>
                     <Routes>
                       <Route path="/" element={<Bugs />} />
@@ -186,13 +721,22 @@ function AppContent() {
                 </div>
               </div>
             </Window>
+            {resizeHandles}
           </div>
         )}
       </div>
       <Taskbar
-        windowTitle={getWindowTitle()}
+        windowTitle={windowTitle}
         minimized={minimized}
-        onToggle={() => setMinimized(v => !v)}
+        hidden={hidden}
+        onToggle={() => {
+          if (hidden) {
+            showWindow()
+            return
+          }
+          setMinimized(value => !value)
+        }}
+        onOpenWindow={showWindow}
       />
     </div>
   )

--- a/src/components/StartMenu.tsx
+++ b/src/components/StartMenu.tsx
@@ -1,42 +1,42 @@
 import { Link } from 'react-router-dom'
 import { raised, sunken, windowShadow } from '../utils/win95'
 
-export default function StartMenu({ onClose }: { onClose: () => void }) {
+type Props = {
+  onClose: () => void
+  onOpenWindow?: () => void
+}
+
+const items = [
+  { to: '/', label: '🐛 Bugs' },
+  { to: '/dashboard', label: '📊 Dashboard' },
+  { to: '/bounty-leaderboard', label: '🏆 Leaderboard' },
+  { to: '/weather', label: '🌦️ Weather' },
+  { to: '/fortune', label: '🥠 Fortune' },
+  { to: '/sign-up', label: '✍️ Sign Up' },
+  { to: '/job-description', label: '📄 Job Description' },
+]
+
+export default function StartMenu({ onClose, onOpenWindow }: Props) {
   const itemClass = `block px-2 py-1 ${raised} bg-[#E0E0E0] hover:${sunken}`
   return (
     <div
-      className={`absolute bottom-8 left-0 w-40 p-2 bg-[#C0C0C0] ${raised} ${windowShadow} text-sm`}
+      className={`absolute bottom-8 left-0 w-44 p-2 bg-[#C0C0C0] ${raised} ${windowShadow} text-sm`}
     >
       <ul className="space-y-1">
-        <li>
-          <Link to="/" onClick={onClose} className={itemClass}>
-            🐛 Bugs
-          </Link>
-        </li>
-        <li>
-          <Link to="/dashboard" onClick={onClose} className={itemClass}>
-            📊 Dashboard
-          </Link>
-        </li>
-        <li>
-          <Link
-            to="/bounty-leaderboard"
-            onClick={onClose}
-            className={itemClass}
-          >
-            🏆 Leaderboard
-          </Link>
-        </li>
-        <li>
-          <Link to="/weather" onClick={onClose} className={itemClass}>
-            🌦️ Weather
-          </Link>
-        </li>
-        <li>
-          <Link to="/sign-up" onClick={onClose} className={itemClass}>
-            ✍️ Sign Up
-          </Link>
-        </li>
+        {items.map(item => (
+          <li key={item.to}>
+            <Link
+              to={item.to}
+              onClick={() => {
+                onOpenWindow?.()
+                onClose()
+              }}
+              className={itemClass}
+            >
+              {item.label}
+            </Link>
+          </li>
+        ))}
       </ul>
     </div>
   )

--- a/src/components/Taskbar.tsx
+++ b/src/components/Taskbar.tsx
@@ -11,6 +11,8 @@ export default function Taskbar({
   windowTitle,
   minimized,
   onToggle,
+  hidden,
+  onOpenWindow,
 }: TaskbarProps) {
   const [time, setTime] = useState(getTime())
   const [open, setOpen] = useState(false)
@@ -32,14 +34,18 @@ export default function Taskbar({
         <span className="text-sm font-bold">Start</span>
       </Win95Button>
       <div className="flex-1 flex items-center px-1">
-        <Win95Button
-          onClick={onToggle}
-          className={`h-6 px-2 flex items-center truncate bg-[#C0C0C0] ${raised} ${
-            minimized ? '' : sunken
-          } active:${sunken}`}
-        >
-          {windowTitle}
-        </Win95Button>
+        {!hidden ? (
+          <Win95Button
+            onClick={onToggle}
+            className={`h-6 px-2 flex items-center truncate bg-[#C0C0C0] ${raised} ${
+              minimized ? '' : sunken
+            } active:${sunken}`}
+          >
+            {windowTitle}
+          </Win95Button>
+        ) : (
+          <div className="h-6 flex-1" aria-hidden />
+        )}
       </div>
       <div className={`h-6 px-2 bg-[#C0C0C0] ${raised} font-mono text-sm`}>
         {time}
@@ -47,7 +53,10 @@ export default function Taskbar({
       {open && (
         <>
           <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />
-          <StartMenu onClose={() => setOpen(false)} />
+          <StartMenu
+            onClose={() => setOpen(false)}
+            onOpenWindow={onOpenWindow}
+          />
         </>
       )}
     </div>

--- a/src/components/win95/DesktopIcon.tsx
+++ b/src/components/win95/DesktopIcon.tsx
@@ -1,0 +1,68 @@
+import { ReactNode } from 'react'
+
+type Props = {
+  icon: ReactNode
+  label: string
+  selected: boolean
+  onSelect: () => void
+  onOpen: () => void
+}
+
+export default function DesktopIcon({
+  icon,
+  label,
+  selected,
+  onSelect,
+  onOpen,
+}: Props) {
+  return (
+    <button
+      type="button"
+      className={`w-24 rounded-sm border border-transparent bg-transparent p-2 text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-black ${
+        selected ? 'bg-[rgba(0,0,128,0.35)] border-white' : ''
+      }`}
+      onClick={event => {
+        event.stopPropagation()
+        onSelect()
+      }}
+      onDoubleClick={event => {
+        event.stopPropagation()
+        onOpen()
+      }}
+      onFocus={onSelect}
+      onKeyDown={event => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault()
+          onOpen()
+        }
+      }}
+    >
+      <div
+        className="text-4xl"
+        style={{ textShadow: '1px 1px 0 rgba(0,0,0,0.7)' }}
+        aria-hidden
+      >
+        {icon}
+      </div>
+      <div className="mt-2 flex justify-center">
+        <span
+          className={`px-1 py-0.5 text-center text-xs leading-tight ${
+            selected
+              ? 'border border-[#C0C0C0] bg-[#000080] text-white'
+              : 'border border-transparent text-white'
+          }`}
+          style={
+            selected
+              ? undefined
+              : {
+                  textShadow: '1px 1px 0 rgba(0,0,0,0.65)',
+                  color: 'rgba(255,255,255,0.9)',
+                }
+          }
+        >
+          {label}
+        </span>
+      </div>
+    </button>
+  )
+}

--- a/src/components/win95/TitleBar.tsx
+++ b/src/components/win95/TitleBar.tsx
@@ -1,13 +1,30 @@
-import { ReactNode } from 'react'
+import { ReactNode, PointerEventHandler } from 'react'
 
 type Props = {
   title: string
   controls?: ReactNode
+  onPointerDown?: PointerEventHandler<HTMLDivElement>
+  onDoubleClick?: () => void
+  active?: boolean
 }
 
-export default function TitleBar({ title, controls }: Props) {
+export default function TitleBar({
+  title,
+  controls,
+  onPointerDown,
+  onDoubleClick,
+  active = true,
+}: Props) {
   return (
-    <div className="h-8 select-none border-b-2 border-b-white bg-[#000080] px-2 text-white z-10">
+    <div
+      className={`h-8 select-none border-b-2 px-2 z-10 ${
+        active
+          ? 'border-b-white bg-[#000080] text-white'
+          : 'border-b-[#C0C0C0] bg-[#808080] text-[#E8E8E8]'
+      }`}
+      onPointerDown={onPointerDown}
+      onDoubleClick={onDoubleClick}
+    >
       <div className="flex h-full items-center justify-between">
         <span className="font-bold tracking-wider">{title}</span>
         {controls}

--- a/src/types/taskbar-props.ts
+++ b/src/types/taskbar-props.ts
@@ -2,4 +2,6 @@ export interface TaskbarProps {
   windowTitle: string
   minimized: boolean
   onToggle: () => void
+  hidden?: boolean
+  onOpenWindow?: () => void
 }


### PR DESCRIPTION
## Summary
- add a draggable, resizable Win95-style window with desktop shortcuts and selection state
- wire the taskbar and start menu to reopen the main window and expand navigation entries
- update TitleBar controls and README copy to reflect the fuller Windows 95 experience

## Testing
- npm run format
- npm run lint
- npm test *(fails: `node: bad option: --experimental-transform-types` in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c87c92c1d4832abd6668e3c8fbe171