### PR TITLE
Build Windows 95 desktop shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ This is a "bug bounty hackathon" project that ironically has more bugs than it f
 - 🐛 **Virtual Bug Extermination**: Because squashing real bugs requires actual skill
 - 📊 **Dashboard with Fancy Charts**: D3.js charts now sport gradients, grids, and zoom
 - 🏆 **Leaderboard System**: Compete with yourself since you're probably the only user
-- 🎨 **Windows 95 UI**: Nothing says "modern web development" like nostalgic 30-year-old design
+- 🎨 **Windows 95 Desktop**: Draggable, resizable windows with desktop icons, right-click menus, and a Start menu-powered taskbar
 - 🗃️ **Zustand State Management**: Because Redux wasn't complicated enough, we needed something "simpler"
 - ⚡ **Blazing Fast Vite**: The only thing fast about this project
 - 🎭 **TypeScript**: Added types everywhere except where they're actually needed
 - 🎨 **Tailwind CSS**: 47KB of utility classes to style 3 buttons
 - 🎬 **Framer Motion**: Animated everything because static websites are for quitters
-- 🖥️ **Windows 95 Taskbar**: Because productivity peaks with a retro clock
+- 🖥️ **Windows 95 Taskbar**: Dynamic buttons for every window plus the retro clock you know and love
 - 📂 **Start Menu**: Authentic start menu for quick navigation
 - 🔍 **Search & Filter**: Hunt bugs and leaderboard entries like a pro
 - ⏰ **PTO Rewards**: Earn ridiculous amounts of time off for each bug you squash
@@ -210,8 +210,8 @@ See [docs/NAMING_CONVENTIONS.md](docs/NAMING_CONVENTIONS.md) for the complete gu
 - `bug-priority-ml.ts`: Logistic regression that pretends to rank urgency
 - `AimCursor.tsx`: Mouse cursor replacement nobody asked for
 - `BugTrendsChart.tsx`: Gradient-filled line chart with zoomable timelines
-- `Taskbar.tsx`: Windows 95 clock for peak nostalgia
-- `StartMenu.tsx`: Clickable start button menu
+- `Taskbar.tsx`: Live clock plus dynamic buttons for every open window
+- `StartMenu.tsx`: Clickable start menu that launches any retro app you like
 - `NotFound.tsx`: A 404 page with jokes for when routing fails
 
 **📊 Dashboard Extravaganza:**

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,199 +1,28 @@
-import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom'
-import { Suspense, lazy, useEffect, useState } from 'react'
-import { useKonamiDarkMode } from './hooks/use-konami-dark-mode'
-import { useAudio } from './hooks/use-audio'
-import { useBugStore } from './store'
-
-const Bugs = lazy(() => import('./routes/Bugs'))
-const Leaderboard = lazy(() => import('./routes/Leaderboard'))
-const UserProfile = lazy(() => import('./routes/UserProfile'))
-const Dashboard = lazy(() => import('./routes/Dashboard'))
-const NewBug = lazy(() => import('./routes/NewBug'))
-const NotFound = lazy(() => import('./routes/NotFound'))
-const EasterEgg = lazy(() => import('./routes/EasterEgg'))
-const Weather = lazy(() => import('./routes/Weather'))
-const SignUp = lazy(() => import('./routes/SignUp'))
-const Fortune = lazy(() => import('./routes/Fortune'))
-const JobDescription = lazy(() => import('./routes/JobDescription'))
-import { Minus, Square, X as CloseIcon } from 'lucide-react'
+import { useEffect } from 'react'
+import { BrowserRouter } from 'react-router-dom'
+import Desktop from './components/Desktop'
 import Taskbar from './components/Taskbar'
 import { AudioContext } from './contexts/AudioContext'
-import Window from './components/win95/Window'
-import TitleBar from './components/win95/TitleBar'
-import TabLink from './components/win95/TabLink'
-import Win95Button from './components/win95/Button'
-function AppContent() {
-  const location = useLocation()
-  const { startAutomaticSystems, stopAutomaticSystems } = useBugStore()
-  const [minimized, setMinimized] = useState(false)
-  const [maximized, setMaximized] = useState(false)
-  const [hidden, setHidden] = useState(false)
+import { DesktopProvider } from './contexts/DesktopContext'
+import { useAudio } from './hooks/use-audio'
+import { useKonamiDarkMode } from './hooks/use-konami-dark-mode'
+import { useBugStore } from './store'
+
+function Win95Shell() {
   useKonamiDarkMode()
+  const { startAutomaticSystems, stopAutomaticSystems } = useBugStore()
 
   useEffect(() => {
     startAutomaticSystems()
     return () => stopAutomaticSystems()
   }, [startAutomaticSystems, stopAutomaticSystems])
 
-  const getWindowTitle = () => {
-    switch (location.pathname) {
-      case '/':
-        return 'Bug Basher'
-      case '/dashboard':
-        return 'Bug Dashboard'
-      case '/bounty-leaderboard':
-        return 'Bug Bounty Leaderboard'
-      case '/bug/new':
-        return 'File a Bug'
-      case '/sign-up':
-        return 'Sign Up'
-      case '/easter-egg':
-        return 'Secret Bug Found'
-      case '/weather':
-        return 'Weather Forecast'
-      case '/fortune':
-        return 'Fortune Cookie'
-      case '/job-description':
-        return 'Job Description'
-      default:
-        if (location.pathname.startsWith('/user/')) return 'User Profile'
-        return 'Page Not Found'
-    }
-  }
-
-  if (hidden) {
-    return (
-      <div className="min-h-screen bg-[#008080] p-4 font-['MS_Sans_Serif','Tahoma',sans-serif] flex flex-col">
-        <div className="flex-grow flex items-center justify-center">
-          <Win95Button onClick={() => setHidden(false)}>
-            Reopen Window
-          </Win95Button>
-        </div>
-        <Taskbar
-          windowTitle={getWindowTitle()}
-          minimized
-          onToggle={() => setHidden(false)}
-        />
-      </div>
-    )
-  }
-
   return (
-    <div className="min-h-screen bg-[#008080] p-4 font-['MS_Sans_Serif','Tahoma',sans-serif] flex flex-col">
-      <div className="flex-grow flex">
-        {!minimized && (
-          <div
-            className={`mx-auto w-full flex-grow flex ${maximized ? '' : 'max-w-7xl'}`}
-          >
-            <Window>
-              <TitleBar
-                title={getWindowTitle()}
-                controls={
-                  <div className="flex gap-px">
-                    {[
-                      {
-                        Icon: Minus,
-                        label: 'Minimize',
-                        onClick: () => setMinimized(true),
-                      },
-                      {
-                        Icon: Square,
-                        label: maximized ? 'Restore' : 'Maximize',
-                        onClick: () => setMaximized(v => !v),
-                      },
-                      {
-                        Icon: CloseIcon,
-                        label: 'Close',
-                        onClick: () => setHidden(true),
-                      },
-                    ].map(({ Icon, label, onClick }) => (
-                      <Win95Button
-                        key={label}
-                        aria-label={label}
-                        onClick={onClick}
-                        className="h-6 w-6 p-0"
-                      >
-                        <Icon className="h-3 w-3 text-black" />
-                      </Win95Button>
-                    ))}
-                  </div>
-                }
-              />
-              <div className="bg-[#E0E0E0] p-3 flex flex-col flex-grow">
-                <div className="mb-4 bg-[#C0C0C0] flex gap-1 p-1 sticky top-0 z-10">
-                  <TabLink to="/" active={location.pathname === '/'}>
-                    🐛 Bugs
-                  </TabLink>
-                  <TabLink
-                    to="/dashboard"
-                    active={location.pathname === '/dashboard'}
-                  >
-                    📊 Dashboard
-                  </TabLink>
-                  <TabLink
-                    to="/bounty-leaderboard"
-                    active={location.pathname === '/bounty-leaderboard'}
-                  >
-                    🏆 Leaderboard
-                  </TabLink>
-                  <TabLink
-                    to="/weather"
-                    active={location.pathname === '/weather'}
-                  >
-                    🌦️ Weather
-                  </TabLink>
-                  <TabLink
-                    to="/fortune"
-                    active={location.pathname === '/fortune'}
-                  >
-                    🥠 Fortune
-                  </TabLink>
-                  <TabLink
-                    to="/sign-up"
-                    active={location.pathname === '/sign-up'}
-                  >
-                    ✍️ Sign Up
-                  </TabLink>
-                  <TabLink
-                    to="/job-description"
-                    active={location.pathname === '/job-description'}
-                  >
-                    📄 Job Description
-                  </TabLink>
-                </div>
-                <div className="p-2 overflow-auto relative z-0 flex-grow flex flex-col">
-                  <Suspense fallback={<div className="p-4">Loading...</div>}>
-                    <Routes>
-                      <Route path="/" element={<Bugs />} />
-                      <Route path="/dashboard" element={<Dashboard />} />
-                      <Route
-                        path="/bounty-leaderboard"
-                        element={<Leaderboard />}
-                      />
-                      <Route path="/weather" element={<Weather />} />
-                      <Route path="/fortune" element={<Fortune />} />
-                      <Route path="/user/:userId" element={<UserProfile />} />
-                      <Route path="/bug/new" element={<NewBug />} />
-                      <Route path="/sign-up" element={<SignUp />} />
-                      <Route
-                        path="/job-description"
-                        element={<JobDescription />}
-                      />
-                      <Route path="/easter-egg" element={<EasterEgg />} />
-                      <Route path="*" element={<NotFound />} />
-                    </Routes>
-                  </Suspense>
-                </div>
-              </div>
-            </Window>
-          </div>
-        )}
+    <div className="min-h-screen bg-[#008080] font-['MS_Sans_Serif','Tahoma',sans-serif]">
+      <div className="flex min-h-screen flex-col gap-2 px-4 py-4">
+        <Desktop />
+        <Taskbar />
       </div>
-      <Taskbar
-        windowTitle={getWindowTitle()}
-        minimized={minimized}
-        onToggle={() => setMinimized(v => !v)}
-      />
     </div>
   )
 }
@@ -202,7 +31,9 @@ export default function App() {
   return (
     <BrowserRouter>
       <AudioContext.Provider value={useAudio()}>
-        <AppContent />
+        <DesktopProvider>
+          <Win95Shell />
+        </DesktopProvider>
       </AudioContext.Provider>
     </BrowserRouter>
   )

--- a/src/components/Desktop.tsx
+++ b/src/components/Desktop.tsx
@@ -1,0 +1,127 @@
+import { useMemo, useState } from 'react'
+import DesktopIcon from './DesktopIcon'
+import DesktopWindow from './DesktopWindow'
+import { useDesktop } from '../contexts/DesktopContext'
+
+const CONTEXT_MENU_WIDTH = 160
+const CONTEXT_MENU_HEIGHT = 110
+
+export default function Desktop() {
+  const { definitions, openWindow, windows, toggleStartMenu, startMenuOpen } =
+    useDesktop()
+  const [selectedIcon, setSelectedIcon] = useState<string | null>(null)
+  const [contextMenu, setContextMenu] = useState<{
+    x: number
+    y: number
+  } | null>(null)
+
+  const shortcuts = useMemo(
+    () => definitions.filter(definition => definition.desktopShortcut),
+    [definitions]
+  )
+
+  const visibleWindows = useMemo(
+    () =>
+      windows
+        .filter(window => !window.isMinimized)
+        .sort((a, b) => a.zIndex - b.zIndex),
+    [windows]
+  )
+
+  const handleDesktopClick = () => {
+    setSelectedIcon(null)
+    setContextMenu(null)
+    if (startMenuOpen) {
+      toggleStartMenu(false)
+    }
+  }
+
+  const handleContextMenu = (event: React.MouseEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    const viewportWidth = window.innerWidth
+    const viewportHeight = window.innerHeight
+    const x = Math.min(event.clientX, viewportWidth - CONTEXT_MENU_WIDTH)
+    const y = Math.min(event.clientY, viewportHeight - CONTEXT_MENU_HEIGHT - 32)
+    setContextMenu({ x, y })
+    setSelectedIcon(null)
+  }
+
+  const handleMenuAction = (action: 'refresh' | 'arrange' | 'properties') => {
+    setContextMenu(null)
+    switch (action) {
+      case 'refresh':
+        window.location.reload()
+        break
+      case 'arrange':
+        setSelectedIcon(null)
+        break
+      case 'properties':
+        openWindow('/job-description')
+        break
+      default:
+        break
+    }
+  }
+
+  return (
+    <div
+      className="relative flex-1 overflow-hidden bg-[#008080]"
+      onClick={handleDesktopClick}
+      onContextMenu={handleContextMenu}
+    >
+      {shortcuts.map((shortcut, index) => (
+        <DesktopIcon
+          key={shortcut.id}
+          id={shortcut.id}
+          icon={shortcut.icon}
+          label={shortcut.title}
+          top={32 + index * 92}
+          selected={selectedIcon === shortcut.id}
+          onSelect={setSelectedIcon}
+          onOpen={() => openWindow(shortcut.path)}
+        />
+      ))}
+
+      {visibleWindows.map(window => (
+        <DesktopWindow key={window.id} windowState={window} />
+      ))}
+
+      {contextMenu && (
+        <div
+          className="absolute z-[999] w-40 border-2 border-white bg-[#C0C0C0] text-sm shadow-[inset_-2px_-2px_0_0_rgba(0,0,0,0.55),inset_2px_2px_0_0_rgba(255,255,255,0.8)]"
+          style={{ left: contextMenu.x, top: contextMenu.y }}
+        >
+          <ul className="divide-y divide-gray-400">
+            <li>
+              <button
+                type="button"
+                className="w-full px-3 py-2 text-left hover:bg-[#000080] hover:text-white"
+                onClick={() => handleMenuAction('refresh')}
+              >
+                🔄 Refresh
+              </button>
+            </li>
+            <li>
+              <button
+                type="button"
+                className="w-full px-3 py-2 text-left hover:bg-[#000080] hover:text-white"
+                onClick={() => handleMenuAction('arrange')}
+              >
+                📁 Arrange Icons
+              </button>
+            </li>
+            <li>
+              <button
+                type="button"
+                className="w-full px-3 py-2 text-left hover:bg-[#000080] hover:text-white"
+                onClick={() => handleMenuAction('properties')}
+              >
+                📋 Properties
+              </button>
+            </li>
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/DesktopIcon.tsx
+++ b/src/components/DesktopIcon.tsx
@@ -1,0 +1,74 @@
+import clsx from 'clsx'
+import { useCallback } from 'react'
+import type { MouseEvent, KeyboardEvent } from 'react'
+
+type DesktopIconProps = {
+  id: string
+  icon: string
+  label: string
+  top: number
+  left?: number
+  selected: boolean
+  onOpen: () => void
+  onSelect: (id: string) => void
+}
+
+export default function DesktopIcon({
+  id,
+  icon,
+  label,
+  top,
+  left = 16,
+  selected,
+  onOpen,
+  onSelect,
+}: DesktopIconProps) {
+  const handleClick = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation()
+      onSelect(id)
+    },
+    [id, onSelect]
+  )
+
+  const handleDoubleClick = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation()
+      onOpen()
+    },
+    [onOpen]
+  )
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLButtonElement>) => {
+      if (event.key === 'Enter') {
+        event.preventDefault()
+        onOpen()
+      }
+    },
+    [onOpen]
+  )
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      onDoubleClick={handleDoubleClick}
+      onKeyDown={handleKeyDown}
+      className={clsx(
+        'absolute flex w-24 flex-col items-center gap-2 rounded px-2 py-3 text-xs text-white focus:outline-none',
+        selected
+          ? 'bg-[rgba(0,0,128,0.6)]'
+          : 'bg-transparent hover:bg-[rgba(0,0,128,0.3)]'
+      )}
+      style={{ top, left }}
+    >
+      <span className="text-3xl" aria-hidden="true">
+        {icon}
+      </span>
+      <span className="text-center leading-tight drop-shadow-[1px_1px_0_rgba(0,0,0,0.8)]">
+        {label}
+      </span>
+    </button>
+  )
+}

--- a/src/components/DesktopWindow.tsx
+++ b/src/components/DesktopWindow.tsx
@@ -1,0 +1,161 @@
+import { Minus, Square, X as CloseIcon } from 'lucide-react'
+import { useCallback } from 'react'
+import type { PointerEvent as ReactPointerEvent } from 'react'
+import AppRoutes from '../routes/AppRoutes'
+import { useDesktop } from '../contexts/DesktopContext'
+import type { WindowState } from '../types/window'
+import Window from './win95/Window'
+import TitleBar from './win95/TitleBar'
+import Win95Button from './win95/Button'
+
+type DesktopWindowProps = {
+  windowState: WindowState
+}
+
+export default function DesktopWindow({ windowState }: DesktopWindowProps) {
+  const {
+    focusWindow,
+    closeWindow,
+    toggleMinimize,
+    toggleMaximize,
+    setWindowPosition,
+    setWindowSize,
+  } = useDesktop()
+
+  const { id, path, title, position, size, zIndex, isMaximized, canResize } =
+    windowState
+
+  const handleDragStart = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (isMaximized) return
+      event.preventDefault()
+      focusWindow(id)
+
+      const startX = event.clientX
+      const startY = event.clientY
+      const { x, y } = position
+
+      const handleMove = (moveEvent: PointerEvent) => {
+        const next = {
+          x: x + (moveEvent.clientX - startX),
+          y: y + (moveEvent.clientY - startY),
+        }
+        setWindowPosition(id, next)
+      }
+
+      const handleUp = () => {
+        window.removeEventListener('pointermove', handleMove)
+        window.removeEventListener('pointerup', handleUp)
+      }
+
+      window.addEventListener('pointermove', handleMove)
+      window.addEventListener('pointerup', handleUp)
+    },
+    [focusWindow, id, isMaximized, position, setWindowPosition]
+  )
+
+  const handleResizeStart = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (!canResize || isMaximized) return
+      event.preventDefault()
+      event.stopPropagation()
+      focusWindow(id)
+
+      const startX = event.clientX
+      const startY = event.clientY
+      const { width, height } = size
+
+      const handleMove = (moveEvent: PointerEvent) => {
+        const nextWidth = width + (moveEvent.clientX - startX)
+        const nextHeight = height + (moveEvent.clientY - startY)
+        setWindowSize(id, { width: nextWidth, height: nextHeight })
+      }
+
+      const handleUp = () => {
+        window.removeEventListener('pointermove', handleMove)
+        window.removeEventListener('pointerup', handleUp)
+      }
+
+      window.addEventListener('pointermove', handleMove)
+      window.addEventListener('pointerup', handleUp)
+    },
+    [canResize, focusWindow, id, isMaximized, setWindowSize, size]
+  )
+
+  const handleFocus = useCallback(() => {
+    focusWindow(id)
+  }, [focusWindow, id])
+
+  const maximizeToggle = useCallback(() => {
+    toggleMaximize(id)
+  }, [id, toggleMaximize])
+
+  const minimizeToggle = useCallback(() => {
+    toggleMinimize(id)
+  }, [id, toggleMinimize])
+
+  const close = useCallback(() => {
+    closeWindow(id)
+  }, [closeWindow, id])
+
+  const boundsStyle = isMaximized
+    ? { left: 0, top: 0, width: '100%', height: '100%' }
+    : {
+        left: position.x,
+        top: position.y,
+        width: size.width,
+        height: size.height,
+      }
+
+  return (
+    <div
+      className="absolute flex flex-col"
+      style={{ ...boundsStyle, zIndex }}
+      onPointerDown={handleFocus}
+    >
+      <Window className="flex h-full flex-col" data-window-id={id}>
+        <TitleBar
+          title={title}
+          onDoubleClick={maximizeToggle}
+          onPointerDown={handleDragStart}
+          controls={
+            <div className="flex gap-px">
+              <Win95Button
+                aria-label="Minimize"
+                onClick={minimizeToggle}
+                className="h-6 w-6 p-0"
+              >
+                <Minus className="h-3 w-3 text-black" />
+              </Win95Button>
+              <Win95Button
+                aria-label={isMaximized ? 'Restore' : 'Maximize'}
+                onClick={maximizeToggle}
+                className="h-6 w-6 p-0"
+              >
+                <Square className="h-3 w-3 text-black" />
+              </Win95Button>
+              <Win95Button
+                aria-label="Close"
+                onClick={close}
+                className="h-6 w-6 p-0"
+              >
+                <CloseIcon className="h-3 w-3 text-black" />
+              </Win95Button>
+            </div>
+          }
+        />
+        <div className="relative flex-1 overflow-hidden bg-[#E0E0E0]">
+          <div className="absolute inset-0 overflow-auto">
+            <AppRoutes location={path} />
+          </div>
+        </div>
+      </Window>
+      {canResize && !isMaximized && (
+        <div
+          className="absolute bottom-1 right-1 h-3 w-3 cursor-se-resize border-b border-r border-black"
+          onPointerDown={handleResizeStart}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/components/StartMenu.tsx
+++ b/src/components/StartMenu.tsx
@@ -1,42 +1,30 @@
-import { Link } from 'react-router-dom'
 import { raised, sunken, windowShadow } from '../utils/win95'
+import { useDesktop } from '../contexts/DesktopContext'
 
-export default function StartMenu({ onClose }: { onClose: () => void }) {
-  const itemClass = `block px-2 py-1 ${raised} bg-[#E0E0E0] hover:${sunken}`
+export default function StartMenu() {
+  const { definitions, openWindow, toggleStartMenu } = useDesktop()
+  const items = definitions.filter(definition => definition.startMenu !== false)
+
   return (
     <div
-      className={`absolute bottom-8 left-0 w-40 p-2 bg-[#C0C0C0] ${raised} ${windowShadow} text-sm`}
+      className={`absolute bottom-8 left-0 z-50 w-48 p-2 bg-[#C0C0C0] ${raised} ${windowShadow} text-sm`}
     >
       <ul className="space-y-1">
-        <li>
-          <Link to="/" onClick={onClose} className={itemClass}>
-            🐛 Bugs
-          </Link>
-        </li>
-        <li>
-          <Link to="/dashboard" onClick={onClose} className={itemClass}>
-            📊 Dashboard
-          </Link>
-        </li>
-        <li>
-          <Link
-            to="/bounty-leaderboard"
-            onClick={onClose}
-            className={itemClass}
-          >
-            🏆 Leaderboard
-          </Link>
-        </li>
-        <li>
-          <Link to="/weather" onClick={onClose} className={itemClass}>
-            🌦️ Weather
-          </Link>
-        </li>
-        <li>
-          <Link to="/sign-up" onClick={onClose} className={itemClass}>
-            ✍️ Sign Up
-          </Link>
-        </li>
+        {items.map(item => (
+          <li key={item.id}>
+            <button
+              type="button"
+              onClick={() => {
+                openWindow(item.path)
+                toggleStartMenu(false)
+              }}
+              className={`flex w-full items-center gap-2 px-2 py-1 ${raised} bg-[#E0E0E0] text-left hover:${sunken}`}
+            >
+              <span aria-hidden="true">{item.icon}</span>
+              <span>{item.startLabel ?? item.title}</span>
+            </button>
+          </li>
+        ))}
       </ul>
     </div>
   )

--- a/src/components/Taskbar.tsx
+++ b/src/components/Taskbar.tsx
@@ -1,53 +1,100 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import clsx from 'clsx'
 import { raised, sunken } from '../utils/win95'
 import StartMenu from './StartMenu'
-import type { TaskbarProps } from '../types/taskbar-props'
 import Win95Button from './win95/Button'
+import { useDesktop } from '../contexts/DesktopContext'
 
 const getTime = () =>
   new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
 
-export default function Taskbar({
-  windowTitle,
-  minimized,
-  onToggle,
-}: TaskbarProps) {
+export default function Taskbar() {
+  const {
+    windows,
+    activeWindowId,
+    toggleMinimize,
+    focusWindow,
+    startMenuOpen,
+    toggleStartMenu,
+  } = useDesktop()
   const [time, setTime] = useState(getTime())
-  const [open, setOpen] = useState(false)
 
   useEffect(() => {
     const id = setInterval(() => setTime(getTime()), 1000)
     return () => clearInterval(id)
   }, [])
 
+  const orderedWindows = useMemo(
+    () => windows.filter(window => window.isOpen),
+    [windows]
+  )
+
+  const activeClasses = useMemo(
+    () =>
+      sunken
+        .split(' ')
+        .map(cls => `active:${cls}`)
+        .join(' '),
+    []
+  )
+
+  const handleTaskbarClick = (windowId: string, minimized: boolean) => {
+    if (minimized) {
+      toggleMinimize(windowId)
+      return
+    }
+
+    if (activeWindowId === windowId) {
+      toggleMinimize(windowId)
+    } else {
+      focusWindow(windowId)
+    }
+  }
+
   return (
     <div
-      className={`h-8 bg-[#C0C0C0] flex items-center px-1 justify-between ${sunken}`}
+      className={`relative flex h-8 shrink-0 items-center justify-between bg-[#C0C0C0] px-1 ${sunken}`}
     >
       <Win95Button
-        onClick={() => setOpen(v => !v)}
-        className={`flex items-center h-6 px-2 gap-1 bg-[#C0C0C0] ${raised} active:${sunken}`}
+        onClick={() => toggleStartMenu()}
+        className={clsx(
+          'flex h-6 items-center gap-1 bg-[#C0C0C0] px-2',
+          startMenuOpen ? sunken : '',
+          !startMenuOpen && activeClasses
+        )}
       >
         <span className="w-3 h-3 bg-[#000080]" />
         <span className="text-sm font-bold">Start</span>
       </Win95Button>
-      <div className="flex-1 flex items-center px-1">
-        <Win95Button
-          onClick={onToggle}
-          className={`h-6 px-2 flex items-center truncate bg-[#C0C0C0] ${raised} ${
-            minimized ? '' : sunken
-          } active:${sunken}`}
-        >
-          {windowTitle}
-        </Win95Button>
+      <div className="flex flex-1 items-center gap-1 px-2">
+        {orderedWindows.map(window => {
+          const isActive = activeWindowId === window.id && !window.isMinimized
+          return (
+            <Win95Button
+              key={window.id}
+              onClick={() => handleTaskbarClick(window.id, window.isMinimized)}
+              className={clsx(
+                'flex h-6 min-w-[8rem] items-center gap-2 truncate px-2 text-left',
+                isActive ? sunken : '',
+                !isActive && !window.isMinimized && activeClasses
+              )}
+            >
+              <span aria-hidden="true">{window.icon}</span>
+              <span className="truncate text-sm">{window.title}</span>
+            </Win95Button>
+          )
+        })}
       </div>
       <div className={`h-6 px-2 bg-[#C0C0C0] ${raised} font-mono text-sm`}>
         {time}
       </div>
-      {open && (
+      {startMenuOpen && (
         <>
-          <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />
-          <StartMenu onClose={() => setOpen(false)} />
+          <div
+            className="fixed inset-0 z-40"
+            onClick={() => toggleStartMenu(false)}
+          />
+          <StartMenu />
         </>
       )}
     </div>

--- a/src/components/win95/TitleBar.tsx
+++ b/src/components/win95/TitleBar.tsx
@@ -1,13 +1,24 @@
-import { ReactNode } from 'react'
+import type { PointerEventHandler, MouseEventHandler, ReactNode } from 'react'
 
 type Props = {
   title: string
   controls?: ReactNode
+  onPointerDown?: PointerEventHandler<HTMLDivElement>
+  onDoubleClick?: MouseEventHandler<HTMLDivElement>
 }
 
-export default function TitleBar({ title, controls }: Props) {
+export default function TitleBar({
+  title,
+  controls,
+  onPointerDown,
+  onDoubleClick,
+}: Props) {
   return (
-    <div className="h-8 select-none border-b-2 border-b-white bg-[#000080] px-2 text-white z-10">
+    <div
+      className="h-8 select-none border-b-2 border-b-white bg-[#000080] px-2 text-white"
+      onPointerDown={onPointerDown}
+      onDoubleClick={onDoubleClick}
+    >
       <div className="flex h-full items-center justify-between">
         <span className="font-bold tracking-wider">{title}</span>
         {controls}

--- a/src/components/win95/Window.tsx
+++ b/src/components/win95/Window.tsx
@@ -1,17 +1,23 @@
+import type { CSSProperties, HTMLAttributes } from 'react'
 import { PropsWithChildren } from 'react'
 import { raised, windowShadow } from '../../utils/win95'
 
 type Props = {
   className?: string
-}
+  style?: CSSProperties
+} & Omit<HTMLAttributes<HTMLDivElement>, 'className' | 'style'>
 
 export default function Window({
   children,
   className = '',
+  style,
+  ...rest
 }: PropsWithChildren<Props>) {
   return (
     <div
       className={`w-full bg-[#C0C0C0] ${raised} ${windowShadow} flex flex-col ${className}`}
+      style={style}
+      {...rest}
     >
       {children}
     </div>

--- a/src/contexts/DesktopContext.tsx
+++ b/src/contexts/DesktopContext.tsx
@@ -1,0 +1,355 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type PropsWithChildren,
+} from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+import {
+  WINDOW_DEFINITIONS,
+  findDefinitionForPath,
+} from '../lib/window-definitions'
+import type { WindowDefinition, WindowState } from '../types/window'
+
+const MIN_WINDOW_WIDTH = 360
+const MIN_WINDOW_HEIGHT = 260
+
+type DesktopContextValue = {
+  windows: WindowState[]
+  activeWindowId: string | null
+  definitions: WindowDefinition[]
+  startMenuOpen: boolean
+  openWindow: (path: string) => void
+  focusWindow: (id: string) => void
+  closeWindow: (id: string) => void
+  toggleMinimize: (id: string) => void
+  toggleMaximize: (id: string) => void
+  setWindowPosition: (id: string, position: { x: number; y: number }) => void
+  setWindowSize: (id: string, size: { width: number; height: number }) => void
+  toggleStartMenu: (open?: boolean) => void
+}
+
+const DesktopContext = createContext<DesktopContextValue | undefined>(undefined)
+
+const getFallbackDefinition = () =>
+  WINDOW_DEFINITIONS.find(definition => definition.id === 'not-found')
+
+export function DesktopProvider({ children }: PropsWithChildren) {
+  const location = useLocation()
+  const navigate = useNavigate()
+  const [windows, setWindows] = useState<WindowState[]>([])
+  const [activeWindowId, setActiveWindowId] = useState<string | null>(null)
+  const [startMenuOpen, setStartMenuOpen] = useState(false)
+  const zIndexRef = useRef(1)
+  const cascadeRef = useRef(0)
+  const suppressedPathsRef = useRef(new Set<string>())
+  const previousPathRef = useRef<string | undefined>()
+
+  const getDefinitionForPath = useCallback((path: string) => {
+    return findDefinitionForPath(path) ?? getFallbackDefinition()
+  }, [])
+
+  const openWindow = useCallback(
+    (path: string) => {
+      const definition = getDefinitionForPath(path)
+      if (!definition) return
+
+      let nextActive: string | null = null
+
+      setWindows(prev => {
+        const existing = prev.find(window => window.path === path)
+        if (existing) {
+          nextActive = existing.id
+          const derivedTitle = definition.getTitle?.(path) ?? existing.title
+          const nextZ = ++zIndexRef.current
+          return prev.map(window =>
+            window.id === existing.id
+              ? {
+                  ...window,
+                  isMinimized: false,
+                  zIndex: nextZ,
+                  title: derivedTitle,
+                }
+              : window
+          )
+        }
+
+        const offset = cascadeRef.current
+        cascadeRef.current = (cascadeRef.current + 32) % 192
+        const nextZ = ++zIndexRef.current
+
+        const newWindow: WindowState = {
+          id: crypto.randomUUID(),
+          definitionId: definition.id,
+          path,
+          title: definition.getTitle?.(path) ?? definition.title,
+          icon: definition.icon,
+          position: {
+            x: definition.defaultPosition.x + offset,
+            y: definition.defaultPosition.y + offset,
+          },
+          size: { ...definition.defaultSize },
+          zIndex: nextZ,
+          isOpen: true,
+          isMinimized: false,
+          isMaximized: false,
+          canResize: definition.resizable ?? true,
+        }
+
+        nextActive = newWindow.id
+        return [...prev, newWindow]
+      })
+
+      if (nextActive) {
+        setActiveWindowId(nextActive)
+      }
+
+      setStartMenuOpen(false)
+    },
+    [getDefinitionForPath]
+  )
+
+  const focusWindow = useCallback((id: string) => {
+    let found = false
+    setWindows(prev =>
+      prev.map(window => {
+        if (window.id !== id) return window
+        found = true
+        const nextZ = ++zIndexRef.current
+        return { ...window, isMinimized: false, zIndex: nextZ }
+      })
+    )
+    if (found) {
+      setActiveWindowId(id)
+      setStartMenuOpen(false)
+    }
+  }, [])
+
+  const toggleMinimize = useCallback((id: string) => {
+    let shouldActivate = false
+    let shouldDeactivate = false
+
+    setWindows(prev =>
+      prev.map(window => {
+        if (window.id !== id) return window
+        if (window.isMinimized) {
+          shouldActivate = true
+          const nextZ = ++zIndexRef.current
+          return { ...window, isMinimized: false, zIndex: nextZ }
+        }
+        shouldDeactivate = true
+        return { ...window, isMinimized: true }
+      })
+    )
+
+    if (shouldActivate) {
+      setActiveWindowId(id)
+    } else if (shouldDeactivate) {
+      setActiveWindowId(previous => (previous === id ? null : previous))
+    }
+
+    setStartMenuOpen(false)
+  }, [])
+
+  const toggleMaximize = useCallback((id: string) => {
+    let toggled = false
+    setWindows(prev =>
+      prev.map(window => {
+        if (window.id !== id) return window
+        toggled = true
+        if (window.isMaximized) {
+          const restore = window.restoreBounds
+          const nextZ = ++zIndexRef.current
+          return {
+            ...window,
+            isMaximized: false,
+            position: restore?.position ?? window.position,
+            size: restore?.size ?? window.size,
+            restoreBounds: undefined,
+            zIndex: nextZ,
+          }
+        }
+        const nextZ = ++zIndexRef.current
+        return {
+          ...window,
+          isMaximized: true,
+          restoreBounds: {
+            position: window.position,
+            size: window.size,
+          },
+          zIndex: nextZ,
+        }
+      })
+    )
+
+    if (toggled) {
+      setActiveWindowId(id)
+    }
+  }, [])
+
+  const closeWindow = useCallback((id: string) => {
+    let closedPath: string | null = null
+    let nextActive: string | null = null
+
+    setWindows(prev => {
+      const closing = prev.find(window => window.id === id)
+      if (closing) {
+        closedPath = closing.path
+      }
+
+      const remaining = prev.filter(window => window.id !== id)
+      const next = remaining
+        .filter(window => !window.isMinimized)
+        .sort((a, b) => b.zIndex - a.zIndex)[0]
+
+      nextActive = next?.id ?? null
+      return remaining
+    })
+
+    if (closedPath) {
+      suppressedPathsRef.current.add(closedPath)
+    }
+
+    setActiveWindowId(previous => (previous === id ? nextActive : previous))
+    setStartMenuOpen(false)
+  }, [])
+
+  const setWindowPosition = useCallback(
+    (id: string, position: { x: number; y: number }) => {
+      setWindows(prev =>
+        prev.map(window =>
+          window.id === id && !window.isMaximized
+            ? { ...window, position }
+            : window
+        )
+      )
+    },
+    []
+  )
+
+  const setWindowSize = useCallback(
+    (id: string, size: { width: number; height: number }) => {
+      setWindows(prev =>
+        prev.map(window => {
+          if (window.id !== id || window.isMaximized || !window.canResize) {
+            return window
+          }
+          return {
+            ...window,
+            size: {
+              width: Math.max(MIN_WINDOW_WIDTH, size.width),
+              height: Math.max(MIN_WINDOW_HEIGHT, size.height),
+            },
+          }
+        })
+      )
+    },
+    []
+  )
+
+  const toggleStartMenu = useCallback((open?: boolean) => {
+    setStartMenuOpen(previous => (typeof open === 'boolean' ? open : !previous))
+  }, [])
+
+  useEffect(() => {
+    const active = windows.find(
+      window => window.id === activeWindowId && !window.isMinimized
+    )
+
+    if (active) {
+      if (location.pathname !== active.path) {
+        navigate(active.path, { replace: true })
+      }
+      return
+    }
+
+    if (!windows.length) {
+      if (location.pathname !== '/') {
+        navigate('/', { replace: true })
+      }
+      return
+    }
+
+    const next = windows
+      .filter(window => !window.isMinimized)
+      .sort((a, b) => b.zIndex - a.zIndex)[0]
+
+    if (next && location.pathname !== next.path) {
+      navigate(next.path, { replace: true })
+    }
+  }, [activeWindowId, windows, navigate, location.pathname])
+
+  useEffect(() => {
+    const path = location.pathname || '/'
+    const hasWindow = windows.some(window => window.path === path)
+
+    if (previousPathRef.current === path && hasWindow) {
+      return
+    }
+
+    previousPathRef.current = path
+
+    if (suppressedPathsRef.current.has(path)) {
+      suppressedPathsRef.current.delete(path)
+      return
+    }
+
+    if (hasWindow) {
+      const existing = windows.find(window => window.path === path)
+      if (existing) {
+        focusWindow(existing.id)
+      }
+      return
+    }
+
+    openWindow(path)
+  }, [location.pathname, windows, focusWindow, openWindow])
+
+  const value = useMemo<DesktopContextValue>(
+    () => ({
+      windows,
+      activeWindowId,
+      definitions: WINDOW_DEFINITIONS,
+      startMenuOpen,
+      openWindow,
+      focusWindow,
+      closeWindow,
+      toggleMinimize,
+      toggleMaximize,
+      setWindowPosition,
+      setWindowSize,
+      toggleStartMenu,
+    }),
+    [
+      windows,
+      activeWindowId,
+      startMenuOpen,
+      openWindow,
+      focusWindow,
+      closeWindow,
+      toggleMinimize,
+      toggleMaximize,
+      setWindowPosition,
+      setWindowSize,
+      toggleStartMenu,
+    ]
+  )
+
+  return (
+    <DesktopContext.Provider value={value}>{children}</DesktopContext.Provider>
+  )
+}
+
+/* eslint-disable-next-line react-refresh/only-export-components */
+export const useDesktop = () => {
+  const context = useContext(DesktopContext)
+  if (!context) {
+    throw new Error('useDesktop must be used within a DesktopProvider')
+  }
+  return context
+}
+

--- a/src/lib/window-definitions.ts
+++ b/src/lib/window-definitions.ts
@@ -1,0 +1,135 @@
+import { useBugStore } from '../store'
+import type { WindowDefinition } from '../types/window'
+
+export const WINDOW_DEFINITIONS: WindowDefinition[] = [
+  {
+    id: 'bugs',
+    title: 'Bug Basher',
+    icon: '🐛',
+    path: '/',
+    desktopShortcut: true,
+    startMenu: true,
+    defaultPosition: { x: 120, y: 80 },
+    defaultSize: { width: 960, height: 640 },
+  },
+  {
+    id: 'dashboard',
+    title: 'Bug Dashboard',
+    icon: '📊',
+    path: '/dashboard',
+    desktopShortcut: true,
+    startMenu: true,
+    defaultPosition: { x: 180, y: 120 },
+    defaultSize: { width: 900, height: 600 },
+  },
+  {
+    id: 'leaderboard',
+    title: 'Bug Bounty Leaderboard',
+    icon: '🏆',
+    path: '/bounty-leaderboard',
+    desktopShortcut: true,
+    startMenu: true,
+    defaultPosition: { x: 240, y: 140 },
+    defaultSize: { width: 840, height: 560 },
+  },
+  {
+    id: 'weather',
+    title: 'Weather Forecast',
+    icon: '🌦️',
+    path: '/weather',
+    desktopShortcut: true,
+    startMenu: true,
+    defaultPosition: { x: 300, y: 160 },
+    defaultSize: { width: 720, height: 520 },
+  },
+  {
+    id: 'fortune',
+    title: 'Fortune Cookie',
+    icon: '🥠',
+    path: '/fortune',
+    desktopShortcut: true,
+    startMenu: true,
+    defaultPosition: { x: 340, y: 200 },
+    defaultSize: { width: 620, height: 480 },
+  },
+  {
+    id: 'sign-up',
+    title: 'Bug Basher Sign Up',
+    icon: '✍️',
+    path: '/sign-up',
+    desktopShortcut: true,
+    startMenu: true,
+    startLabel: 'Sign Up',
+    defaultPosition: { x: 380, y: 220 },
+    defaultSize: { width: 640, height: 540 },
+  },
+  {
+    id: 'new-bug',
+    title: 'File a Bug',
+    icon: '🪲',
+    path: '/bug/new',
+    startMenu: true,
+    defaultPosition: { x: 420, y: 240 },
+    defaultSize: { width: 720, height: 560 },
+  },
+  {
+    id: 'job-description',
+    title: 'Job Description',
+    icon: '📄',
+    path: '/job-description',
+    desktopShortcut: true,
+    startMenu: true,
+    defaultPosition: { x: 160, y: 200 },
+    defaultSize: { width: 720, height: 520 },
+  },
+  {
+    id: 'easter-egg',
+    title: 'Secret Bug Found',
+    icon: '🥚',
+    path: '/easter-egg',
+    startMenu: true,
+    defaultPosition: { x: 200, y: 240 },
+    defaultSize: { width: 520, height: 420 },
+  },
+  {
+    id: 'user-profile',
+    title: 'User Profile',
+    icon: '👤',
+    path: '/user/:id',
+    startMenu: false,
+    defaultPosition: { x: 260, y: 260 },
+    defaultSize: { width: 720, height: 520 },
+    getTitle: path => {
+      const segments = path.split('/')
+      const userId = segments[segments.length - 1]
+      if (!userId) return 'User Profile'
+      const user = useBugStore
+        .getState()
+        .users.find(candidate => String(candidate.id) === userId)
+      return user ? `${user.name}` : 'User Profile'
+    },
+    match: path => /^\/user\//.test(path),
+  },
+  {
+    id: 'not-found',
+    title: 'Page Not Found',
+    icon: '💥',
+    path: '*',
+    startMenu: false,
+    defaultPosition: { x: 200, y: 160 },
+    defaultSize: { width: 540, height: 420 },
+  },
+]
+
+export const findDefinitionForPath = (
+  path: string
+): WindowDefinition | undefined => {
+  const exactMatch = WINDOW_DEFINITIONS.find(
+    definition => definition.path === path
+  )
+  if (exactMatch) {
+    return exactMatch
+  }
+
+  return WINDOW_DEFINITIONS.find(definition => definition.match?.(path))
+}

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -1,0 +1,38 @@
+import { Suspense, lazy } from 'react'
+import { Route, Routes } from 'react-router-dom'
+
+type Props = {
+  location?: string
+}
+
+const Bugs = lazy(() => import('./Bugs'))
+const Leaderboard = lazy(() => import('./Leaderboard'))
+const UserProfile = lazy(() => import('./UserProfile'))
+const Dashboard = lazy(() => import('./Dashboard'))
+const NewBug = lazy(() => import('./NewBug'))
+const NotFound = lazy(() => import('./NotFound'))
+const EasterEgg = lazy(() => import('./EasterEgg'))
+const Weather = lazy(() => import('./Weather'))
+const SignUp = lazy(() => import('./SignUp'))
+const Fortune = lazy(() => import('./Fortune'))
+const JobDescription = lazy(() => import('./JobDescription'))
+
+export default function AppRoutes({ location }: Props) {
+  return (
+    <Suspense fallback={<div className="p-4 text-sm">Loading...</div>}>
+      <Routes location={location}>
+        <Route path="/" element={<Bugs />} />
+        <Route path="/dashboard" element={<Dashboard />} />
+        <Route path="/bounty-leaderboard" element={<Leaderboard />} />
+        <Route path="/weather" element={<Weather />} />
+        <Route path="/fortune" element={<Fortune />} />
+        <Route path="/user/:userId" element={<UserProfile />} />
+        <Route path="/bug/new" element={<NewBug />} />
+        <Route path="/sign-up" element={<SignUp />} />
+        <Route path="/job-description" element={<JobDescription />} />
+        <Route path="/easter-egg" element={<EasterEgg />} />
+        <Route path="*" element={<NotFound />} />
+      </Routes>
+    </Suspense>
+  )
+}

--- a/src/types/taskbar-props.ts
+++ b/src/types/taskbar-props.ts
@@ -1,5 +1,0 @@
-export interface TaskbarProps {
-  windowTitle: string
-  minimized: boolean
-  onToggle: () => void
-}

--- a/src/types/window.ts
+++ b/src/types/window.ts
@@ -1,0 +1,44 @@
+export type WindowDefinition = {
+  id: string
+  /** Base title shown in taskbar/start menu */
+  title: string
+  /** Emoji or icon used for shortcuts */
+  icon: string
+  /** Canonical route path for this window */
+  path: string
+  /** Whether to render a shortcut on the desktop */
+  desktopShortcut?: boolean
+  /** Whether to list this window inside the start menu */
+  startMenu?: boolean
+  /** Optional label override for the start menu */
+  startLabel?: string
+  /** Initial position for the window */
+  defaultPosition: { x: number; y: number }
+  /** Initial size for the window */
+  defaultSize: { width: number; height: number }
+  /** Allow resizing via corner handle */
+  resizable?: boolean
+  /** Predicate for matching dynamic routes (e.g. /user/:id) */
+  match?: (path: string) => boolean
+  /** Optional dynamic title derivation based on path */
+  getTitle?: (path: string) => string
+}
+
+export type WindowState = {
+  id: string
+  definitionId: string
+  path: string
+  title: string
+  icon: string
+  position: { x: number; y: number }
+  size: { width: number; height: number }
+  zIndex: number
+  isOpen: boolean
+  isMinimized: boolean
+  isMaximized: boolean
+  canResize: boolean
+  restoreBounds?: {
+    position: { x: number; y: number }
+    size: { width: number; height: number }
+  }
+}


### PR DESCRIPTION
## Summary
- replace the single routed window with a DesktopProvider-driven Windows 95 shell that shows shortcuts, context menus, and keeps URL state in sync
- add draggable, resizable DesktopWindow components that render AppRoutes per window and sync with an upgraded taskbar/start menu
- document the new Windows 95 desktop experience in the README

## Testing
- npm run format
- npm run lint
- npm test *(fails: Node does not recognize the experimental flags bundled with the script)*

------
https://chatgpt.com/codex/tasks/task_e_68c87c92c1d4832abd6668e3c8fbe171