### PR TITLE
Show all desktop shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ This is a "bug bounty hackathon" project that ironically has more bugs than it f
 - 🎬 **Framer Motion**: Animated everything because static websites are for quitters
 - 🖥️ **Windows 95 Taskbar**: Because productivity peaks with a retro clock
 - 📂 **Start Menu**: Authentic start menu for quick navigation
+- 🗂️ **Desktop Shortcuts Everywhere**: Every page now shows up on the desktop for
+  quick double-click access
 - 🔍 **Search & Filter**: Hunt bugs and leaderboard entries like a pro
 - ⏰ **PTO Rewards**: Earn ridiculous amounts of time off for each bug you squash
 - 🧹 **Automatic Cleanup**: Squashed bugs vanish on their own, only to respawn

--- a/src/components/Desktop.tsx
+++ b/src/components/Desktop.tsx
@@ -7,12 +7,17 @@ import { DESKTOP_SHORTCUTS } from '../utils/window-apps'
 import type { WindowSize } from '../types/window'
 
 const DEFAULT_SIZE: WindowSize = { width: 1024, height: 720 }
+const CONTAINER_PADDING = 32 // Tailwind p-4
+const ICON_GAP = 24 // Tailwind gap-6
+const DEFAULT_ICON_SIZE = { width: 96, height: 112 }
 
 export default function Desktop() {
   const containerRef = useRef<HTMLDivElement | null>(null)
   const [containerSize, setContainerSize] = useState<WindowSize>(DEFAULT_SIZE)
+  const [iconSize, setIconSize] = useState(DEFAULT_ICON_SIZE)
   const { windows, openWindow } = useWindowManager()
   const initializedRef = useRef(false)
+  const firstIconRef = useRef<HTMLButtonElement | null>(null)
 
   useEffect(() => {
     if (!initializedRef.current) {
@@ -43,10 +48,80 @@ export default function Desktop() {
     return () => window.removeEventListener('resize', handleResize)
   }, [])
 
+  useEffect(() => {
+    const element = firstIconRef.current
+    if (!element) return
+
+    const updateIconSize = () => {
+      setIconSize({
+        width: element.offsetWidth,
+        height: element.offsetHeight,
+      })
+    }
+
+    updateIconSize()
+
+    if (typeof ResizeObserver !== 'undefined') {
+      const observer = new ResizeObserver(updateIconSize)
+      observer.observe(element)
+      return () => observer.disconnect()
+    }
+
+    window.addEventListener('resize', updateIconSize)
+    return () => window.removeEventListener('resize', updateIconSize)
+  }, [])
+
   const sortedWindows = useMemo(
     () => [...windows].sort((a, b) => a.zIndex - b.zIndex),
     [windows]
   )
+
+  const shortcutsByColumn = useMemo(() => {
+    const totalShortcuts = DESKTOP_SHORTCUTS.length
+    if (totalShortcuts === 0) return []
+
+    const availableHeight = Math.max(
+      0,
+      containerSize.height - CONTAINER_PADDING
+    )
+    const availableWidth = Math.max(0, containerSize.width - CONTAINER_PADDING)
+
+    const iconHeightWithGap = iconSize.height + ICON_GAP
+    const iconWidthWithGap = iconSize.width + ICON_GAP
+
+    const maxRows = iconHeightWithGap
+      ? Math.max(
+          1,
+          Math.floor((availableHeight + ICON_GAP) / iconHeightWithGap)
+        )
+      : totalShortcuts
+
+    const columnsByHeight =
+      maxRows >= totalShortcuts ? 1 : Math.ceil(totalShortcuts / maxRows)
+
+    const maxColumnsByWidth = iconWidthWithGap
+      ? Math.max(1, Math.floor((availableWidth + ICON_GAP) / iconWidthWithGap))
+      : totalShortcuts
+
+    const columnCount = Math.max(
+      1,
+      Math.min(columnsByHeight, maxColumnsByWidth)
+    )
+
+    const rowsPerColumn = Math.ceil(totalShortcuts / columnCount)
+
+    return Array.from({ length: columnCount }, (_, columnIndex) =>
+      DESKTOP_SHORTCUTS.slice(
+        columnIndex * rowsPerColumn,
+        columnIndex * rowsPerColumn + rowsPerColumn
+      )
+    )
+  }, [
+    containerSize.height,
+    containerSize.width,
+    iconSize.height,
+    iconSize.width,
+  ])
 
   return (
     <div className="min-h-screen bg-[#008080] font-['MS_Sans_Serif','Tahoma',sans-serif] flex flex-col text-black">
@@ -55,9 +130,21 @@ export default function Desktop() {
         className="relative flex-1 overflow-hidden p-4"
         role="presentation"
       >
-        <div className="grid grid-cols-1 gap-6 content-start">
-          {DESKTOP_SHORTCUTS.map(app => (
-            <DesktopIcon key={app.id} app={app} />
+        <div className="flex h-full items-start gap-6">
+          {shortcutsByColumn.map((column, columnIndex) => (
+            <div key={`column-${columnIndex}`} className="flex flex-col gap-6">
+              {column.map((app, itemIndex) => (
+                <DesktopIcon
+                  key={app.id}
+                  app={app}
+                  ref={
+                    columnIndex === 0 && itemIndex === 0
+                      ? firstIconRef
+                      : undefined
+                  }
+                />
+              ))}
+            </div>
           ))}
         </div>
 

--- a/src/components/DesktopIcon.tsx
+++ b/src/components/DesktopIcon.tsx
@@ -1,40 +1,47 @@
-import { useState } from 'react'
+import { forwardRef, useState } from 'react'
 import { useWindowManager } from '../contexts/WindowManagerContext'
 import type { WindowAppDefinition } from '../utils/window-apps'
 
 const baseClasses =
   'flex flex-col items-center justify-center w-24 gap-2 text-center text-white cursor-default select-none bg-transparent border-none !px-0 !py-3 focus:outline-none focus-visible:outline focus-visible:outline-offset-1 focus-visible:outline-white'
 
-export default function DesktopIcon({ app }: { app: WindowAppDefinition }) {
-  const { openWindow } = useWindowManager()
-  const [selected, setSelected] = useState(false)
+const DesktopIcon = forwardRef<HTMLButtonElement, { app: WindowAppDefinition }>(
+  ({ app }, ref) => {
+    const { openWindow } = useWindowManager()
+    const [selected, setSelected] = useState(false)
 
-  return (
-    <button
-      type="button"
-      onClick={() => setSelected(true)}
-      onDoubleClick={() => {
-        openWindow(app.id)
-        setSelected(false)
-      }}
-      className={`${baseClasses} focus:outline-none`}
-    >
-      <span
-        className={`flex h-12 w-12 items-center justify-center rounded ${
-          selected ? 'bg-[#000080] border border-white' : ''
-        }`}
+    return (
+      <button
+        type="button"
+        onClick={() => setSelected(true)}
+        onDoubleClick={() => {
+          openWindow(app.id)
+          setSelected(false)
+        }}
+        className={`${baseClasses} focus:outline-none`}
+        ref={ref}
       >
-        <span className="text-2xl" aria-hidden>
-          {app.icon}
+        <span
+          className={`flex h-12 w-12 items-center justify-center rounded ${
+            selected ? 'bg-[#000080] border border-white' : ''
+          }`}
+        >
+          <span className="text-2xl" aria-hidden>
+            {app.icon}
+          </span>
         </span>
-      </span>
-      <span
-        className={`px-1 text-sm leading-tight ${
-          selected ? 'bg-[#000080] border border-white' : 'bg-[#000080]/0'
-        }`}
-      >
-        {app.title}
-      </span>
-    </button>
-  )
-}
+        <span
+          className={`px-1 text-sm leading-tight ${
+            selected ? 'bg-[#000080] border border-white' : 'bg-[#000080]/0'
+          }`}
+        >
+          {app.title}
+        </span>
+      </button>
+    )
+  }
+)
+
+DesktopIcon.displayName = 'DesktopIcon'
+
+export default DesktopIcon

--- a/src/utils/window-apps.ts
+++ b/src/utils/window-apps.ts
@@ -72,7 +72,7 @@ export const WINDOW_APPS: Record<WindowAppId, WindowAppDefinition> = {
     icon: '🥠',
     Component: Fortune,
     defaultSize: { width: 520, height: 480 },
-    desktopShortcut: false,
+    desktopShortcut: true,
     startMenuShortcut: true,
   },
   signUp: {
@@ -81,7 +81,7 @@ export const WINDOW_APPS: Record<WindowAppId, WindowAppDefinition> = {
     icon: '✍️',
     Component: SignUp,
     defaultSize: { width: 560, height: 620 },
-    desktopShortcut: false,
+    desktopShortcut: true,
     startMenuShortcut: true,
   },
   newBug: {
@@ -90,7 +90,7 @@ export const WINDOW_APPS: Record<WindowAppId, WindowAppDefinition> = {
     icon: '🪳',
     Component: NewBug,
     defaultSize: { width: 640, height: 720 },
-    desktopShortcut: false,
+    desktopShortcut: true,
     startMenuShortcut: true,
   },
   jobDescription: {
@@ -99,7 +99,7 @@ export const WINDOW_APPS: Record<WindowAppId, WindowAppDefinition> = {
     icon: '📄',
     Component: JobDescription,
     defaultSize: { width: 720, height: 640 },
-    desktopShortcut: false,
+    desktopShortcut: true,
     startMenuShortcut: true,
   },
   easterEgg: {


### PR DESCRIPTION
## Summary
- enable desktop shortcuts for all of the start menu app pages so every route is accessible from the desktop
- update the README to mention that every page now has a desktop shortcut

## Testing
- npm run format
- npm run lint
- npm test *(fails in this environment: Node 20.19.4 does not support `--experimental-transform-types` and related coverage flags)*

------
https://chatgpt.com/codex/tasks/task_e_68c886c86b80832aafa17c2a78817174