### PR TITLE
Add Windows 95 window controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ This is a "bug bounty hackathon" project that ironically has more bugs than it f
 - 📊 **Dashboard with Fancy Charts**: D3.js charts now sport gradients, grids, and zoom
 - 🏆 **Leaderboard System**: Compete with yourself since you're probably the only user
 - 🎨 **Windows 95 UI**: Nothing says "modern web development" like nostalgic 30-year-old design
+- 🪟 **Pixel-Perfect Window Controls**: Title bars now rock the classic `_`, `□`, and `X` glyphs straight out of Windows 95
 - 🖱️ **Authentic Desktop Shell**: Draggable, resizable windows with minimize/maximize controls, a living taskbar, and a Start menu that launches every feature
 - 🗃️ **Zustand State Management**: Because Redux wasn't complicated enough, we needed something "simpler"
 - ⚡ **Blazing Fast Vite**: The only thing fast about this project

--- a/src/components/DesktopWindow.tsx
+++ b/src/components/DesktopWindow.tsx
@@ -1,9 +1,13 @@
 import { Suspense } from 'react'
 import { Rnd } from 'react-rnd'
-import { Minus, Square, X as CloseIcon } from 'lucide-react'
 import Window from './win95/Window'
 import TitleBar from './win95/TitleBar'
 import Win95Button from './win95/Button'
+import {
+  Win95CloseIcon,
+  Win95MaximizeIcon,
+  Win95MinimizeIcon,
+} from './win95/WindowControlIcons'
 import { useWindowManager } from '../contexts/WindowManagerContext'
 import { WINDOW_APPS } from '../utils/window-apps'
 import type { WindowSize, WindowState } from '../types/window'
@@ -74,21 +78,21 @@ export default function DesktopWindow({ windowState, containerSize }: Props) {
                 aria-label="Minimize"
                 className={CONTROL_BUTTON_CLASS}
               >
-                <Minus className="h-3 w-3 text-black" />
+                <Win95MinimizeIcon />
               </Win95Button>
               <Win95Button
                 onClick={handleMaximize}
                 aria-label={windowState.maximized ? 'Restore' : 'Maximize'}
                 className={CONTROL_BUTTON_CLASS}
               >
-                <Square className="h-3 w-3 text-black" />
+                <Win95MaximizeIcon />
               </Win95Button>
               <Win95Button
                 onClick={() => closeWindow(windowState.id)}
                 aria-label="Close"
                 className={CONTROL_BUTTON_CLASS}
               >
-                <CloseIcon className="h-3 w-3 text-black" />
+                <Win95CloseIcon />
               </Win95Button>
             </div>
           }

--- a/src/components/win95/WindowControlIcons.tsx
+++ b/src/components/win95/WindowControlIcons.tsx
@@ -1,0 +1,87 @@
+import clsx from 'clsx'
+import type { SVGProps } from 'react'
+
+const HIGHLIGHT = '#FFFFFF'
+const SHADOW = '#808080'
+const FACE = '#C0C0C0'
+const OUTLINE = '#000000'
+
+type IconProps = SVGProps<SVGSVGElement>
+
+export function Win95MinimizeIcon({ className, ...props }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 12 12"
+      aria-hidden="true"
+      focusable="false"
+      shapeRendering="crispEdges"
+      className={clsx('h-3 w-3', className)}
+      {...props}
+    >
+      <rect x="2" y="7" width="8" height="1" fill={OUTLINE} />
+      <rect x="2" y="8" width="8" height="1" fill={SHADOW} />
+    </svg>
+  )
+}
+
+export function Win95MaximizeIcon({ className, ...props }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 12 12"
+      aria-hidden="true"
+      focusable="false"
+      shapeRendering="crispEdges"
+      className={clsx('h-3 w-3', className)}
+      {...props}
+    >
+      <rect x="2" y="2" width="8" height="6" fill={FACE} />
+      <path d="M2.5 2.5H9.5" stroke={HIGHLIGHT} strokeWidth="1" />
+      <path d="M2.5 2.5V7.5" stroke={HIGHLIGHT} strokeWidth="1" />
+      <path d="M2.5 7.5H9.5" stroke={OUTLINE} strokeWidth="1" />
+      <path d="M9.5 2.5V7.5" stroke={OUTLINE} strokeWidth="1" />
+      <rect x="3" y="3" width="6" height="4" fill={HIGHLIGHT} />
+      <path d="M3.5 3.5H8.5" stroke={OUTLINE} strokeWidth="1" />
+      <path d="M3.5 3.5V6.5" stroke={OUTLINE} strokeWidth="1" />
+      <path d="M3.5 6.5H8.5" stroke={SHADOW} strokeWidth="1" />
+      <path d="M8.5 3.5V6.5" stroke={SHADOW} strokeWidth="1" />
+    </svg>
+  )
+}
+
+export function Win95CloseIcon({ className, ...props }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 12 12"
+      aria-hidden="true"
+      focusable="false"
+      shapeRendering="crispEdges"
+      className={clsx('h-3 w-3', className)}
+      {...props}
+    >
+      <path
+        d="M3.5 3.5L8.5 8.5"
+        stroke={OUTLINE}
+        strokeWidth="1"
+        strokeLinecap="square"
+      />
+      <path
+        d="M3.5 8.5L8.5 3.5"
+        stroke={OUTLINE}
+        strokeWidth="1"
+        strokeLinecap="square"
+      />
+      <path
+        d="M4.5 3.5L8.5 7.5"
+        stroke={HIGHLIGHT}
+        strokeWidth="1"
+        strokeLinecap="square"
+      />
+      <path
+        d="M3.5 4.5L7.5 8.5"
+        stroke={HIGHLIGHT}
+        strokeWidth="1"
+        strokeLinecap="square"
+      />
+    </svg>
+  )
+}


### PR DESCRIPTION
## Summary
- add pixel-perfect Windows 95 style SVG icons for minimize, maximize, and close buttons
- wire the new icons into the desktop window title bar so every window shows the classic glyphs
- document the nostalgic control icons in the feature list

## Testing
- npm run format
- npm run lint
- npm test *(fails: current Node version does not recognize --experimental-transform-types / --test-coverage-include flags)*

------
https://chatgpt.com/codex/tasks/task_e_68c8869db7d4832abd5b945a32307709