### PR TITLE
Recreate Windows 95 taskbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This is a "bug bounty hackathon" project that ironically has more bugs than it f
 - 🎭 **TypeScript**: Added types everywhere except where they're actually needed
 - 🎨 **Tailwind CSS**: 47KB of utility classes to style 3 buttons
 - 🎬 **Framer Motion**: Animated everything because static websites are for quitters
-- 🖥️ **Windows 95 Taskbar**: Because productivity peaks with a retro clock
+- 🖥️ **Windows 95 Taskbar**: Pixel-perfect Start button, beveled task list, and system tray clock straight from 1995
 - 📂 **Start Menu**: Authentic start menu for quick navigation
 - 🔍 **Search & Filter**: Hunt bugs and leaderboard entries like a pro
 - ⏰ **PTO Rewards**: Earn ridiculous amounts of time off for each bug you squash

--- a/src/components/StartMenu.tsx
+++ b/src/components/StartMenu.tsx
@@ -8,7 +8,7 @@ export default function StartMenu({ onClose }: { onClose: () => void }) {
 
   return (
     <div
-      className={`absolute bottom-8 left-0 w-48 p-2 bg-[#C0C0C0] ${raised} ${windowShadow} text-sm z-50`}
+      className={`absolute left-[4px] bottom-[calc(100%+4px)] w-48 p-2 bg-[#C0C0C0] ${raised} ${windowShadow} text-sm z-50`}
     >
       <ul className="space-y-1">
         {START_MENU_APPS.map(app => (

--- a/src/components/Taskbar.tsx
+++ b/src/components/Taskbar.tsx
@@ -129,7 +129,7 @@ export default function Taskbar() {
       <Divider />
 
       <div
-        className={`flex h-9 flex-1 items-center gap-1 overflow-hidden bg-[#BDBDBD] px-2 ${thinSunken}`}
+        className={`flex h-9 flex-1 items-center gap-1 overflow-x-auto overflow-y-hidden bg-[#BDBDBD] px-2 ${thinSunken}`}
       >
         {orderedWindows.map(window => {
           const definition = apps[window.appId]

--- a/src/components/Taskbar.tsx
+++ b/src/components/Taskbar.tsx
@@ -1,11 +1,108 @@
 import { useEffect, useMemo, useState } from 'react'
-import { raised, sunken } from '../utils/win95'
 import StartMenu from './StartMenu'
 import Win95Button from './win95/Button'
 import { useWindowManager } from '../contexts/WindowManagerContext'
+import { sunken } from '../utils/win95'
 
 const getTime = () =>
   new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+
+const taskbarFrame =
+  'shadow-[inset_0_1px_0_0_#ffffff,inset_0_2px_0_0_#dfdfdf,inset_0_-1px_0_0_#808080,inset_0_-2px_0_0_#404040]'
+
+const thinSunken =
+  'border border-t-[#808080] border-l-[#808080] border-b-white border-r-white'
+
+type StartButtonProps = {
+  open: boolean
+  onClick: () => void
+}
+
+function StartButton({ open, onClick }: StartButtonProps) {
+  const base =
+    'relative flex h-9 items-center gap-2 px-4 text-[13px] font-semibold tracking-tight text-black select-none'
+  const gradient =
+    'bg-[linear-gradient(180deg,#3fc162_0%,#35a854_35%,#2b8a45_70%,#1f6d37_100%)]'
+  const raisedStyles =
+    'border-[2px] border-t-[#f5f5f5] border-l-[#f5f5f5] border-r-[#404040] border-b-[#404040] shadow-[inset_1px_1px_0_0_#5fd27a,inset_-1px_-1px_0_0_#1b6f2b]'
+  const sunkenStyles =
+    'border-[2px] border-t-[#404040] border-l-[#404040] border-r-[#f5f5f5] border-b-[#f5f5f5] shadow-[inset_1px_1px_0_0_#1b6f2b,inset_-1px_-1px_0_0_#5fd27a]'
+
+  return (
+    <button
+      type="button"
+      aria-pressed={open}
+      onClick={onClick}
+      className={`${base} ${gradient} ${open ? sunkenStyles : raisedStyles} focus:outline-none focus-visible:ring-2 focus-visible:ring-black`}
+    >
+      <WindowsLogo className="h-4 w-4" />
+      <span className="tracking-[0.02em]">Start</span>
+    </button>
+  )
+}
+
+function WindowsLogo({ className = '' }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 28 28"
+      role="presentation"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path d="M1 6.5L12.5 4v7L1 12.5V6.5Z" fill="#f35325" />
+      <path d="M14 3.5L27 1v10.5L14 11.5V3.5Z" fill="#07a6f0" />
+      <path d="M1 14L12.5 15.5v7L1 19.5V14Z" fill="#ffba08" />
+      <path d="M14 16l13 1.5V27L14 24.5V16Z" fill="#00b050" />
+    </svg>
+  )
+}
+
+function Divider() {
+  return (
+    <div className="flex h-9 w-[3px] items-stretch" aria-hidden="true">
+      <div className="w-px bg-[#808080]" />
+      <div className="w-px bg-white" />
+    </div>
+  )
+}
+
+function SpeakerIcon({ className = '' }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      className={className}
+      role="presentation"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path d="M1.5 6.5h2.9L7.5 4v8L4.4 9.5H1.5v-3Z" fill="#000" />
+      <path
+        d="M10 6v4M12 5v6"
+        stroke="#000"
+        strokeWidth="1.2"
+        strokeLinecap="round"
+      />
+    </svg>
+  )
+}
+
+function MonitorIcon({ className = '' }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      className={className}
+      role="presentation"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <rect x="1" y="3" width="14" height="9" fill="#000" />
+      <rect x="2" y="4" width="12" height="7" fill="#C0C0C0" />
+      <rect x="5" y="13" width="6" height="1.5" fill="#000" />
+      <rect x="4" y="14.5" width="8" height="1" fill="#808080" />
+    </svg>
+  )
+}
 
 export default function Taskbar() {
   const { windows, activeWindowId, toggleMinimize, focusWindow, apps } =
@@ -25,17 +122,15 @@ export default function Taskbar() {
 
   return (
     <div
-      className={`relative h-10 bg-[#C0C0C0] flex items-center px-2 ${sunken}`}
+      className={`relative flex h-12 items-center gap-2 bg-[#C0C0C0] px-3 text-[13px] ${taskbarFrame}`}
     >
-      <Win95Button
-        onClick={() => setOpen(v => !v)}
-        className={`flex items-center h-7 px-3 gap-2 bg-[#C0C0C0] ${raised} active:${sunken}`}
-      >
-        <span className="w-3 h-3 bg-[#000080]" />
-        <span className="text-sm font-bold">Start</span>
-      </Win95Button>
+      <StartButton open={open} onClick={() => setOpen(value => !value)} />
 
-      <div className="flex-1 flex items-center px-2 gap-2 overflow-x-auto">
+      <Divider />
+
+      <div
+        className={`flex h-9 flex-1 items-center gap-1 overflow-hidden bg-[#BDBDBD] px-2 ${thinSunken}`}
+      >
         {orderedWindows.map(window => {
           const definition = apps[window.appId]
           const isActive = activeWindowId === window.id && !window.minimized
@@ -50,21 +145,31 @@ export default function Taskbar() {
                   focusWindow(window.id)
                 }
               }}
-              className={`h-7 px-3 flex items-center gap-2 truncate bg-[#C0C0C0] ${raised} ${
+              className={`flex h-7 min-w-[140px] flex-shrink-0 items-center gap-2 truncate bg-[#C0C0C0] px-3 text-left ${
                 isActive ? sunken : ''
               }`}
             >
               <span aria-hidden>{definition?.icon ?? '🪟'}</span>
-              <span className="truncate max-w-[12rem] text-left">
-                {window.title}
-              </span>
+              <span className="truncate text-left">{window.title}</span>
             </Win95Button>
           )
         })}
       </div>
 
-      <div className={`h-7 px-3 bg-[#C0C0C0] ${raised} font-mono text-sm`}>
-        {time}
+      <Divider />
+
+      <div className="flex h-9 items-center gap-2">
+        <div
+          className={`flex h-full items-center gap-2 px-2 ${thinSunken} bg-[#C0C0C0]`}
+        >
+          <MonitorIcon className="h-4 w-4" />
+          <SpeakerIcon className="h-4 w-4" />
+        </div>
+        <div
+          className={`flex h-full min-w-[88px] items-center justify-center px-3 font-['MS_Sans_Serif','Tahoma',sans-serif] ${thinSunken} bg-[#C0C0C0]`}
+        >
+          {time}
+        </div>
       </div>
 
       {open && (


### PR DESCRIPTION
## Summary
- restyle the taskbar with Windows 95 accurate bevels, start button, and system tray icons
- reposition the start menu to sit against the taskbar frame and document the update in the README

## Testing
- npm run format
- npm run lint
- npm test *(fails: node: bad option: --experimental-transform-types)*

------
https://chatgpt.com/codex/tasks/task_e_68c886efdd98832aa80b90f5186c6230