### PR TITLE
Recreate Windows 95 taskbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This is a "bug bounty hackathon" project that ironically has more bugs than it f
 - 🎭 **TypeScript**: Added types everywhere except where they're actually needed
 - 🎨 **Tailwind CSS**: 47KB of utility classes to style 3 buttons
 - 🎬 **Framer Motion**: Animated everything because static websites are for quitters
-- 🖥️ **Windows 95 Taskbar**: Because productivity peaks with a retro clock
+- 🖥️ **Windows 95 Taskbar**: Pixel-perfect Start button, separators, and tray clock nostalgia
 - 📂 **Start Menu**: Authentic start menu for quick navigation
 - 🔍 **Search & Filter**: Hunt bugs and leaderboard entries like a pro
 - ⏰ **PTO Rewards**: Earn ridiculous amounts of time off for each bug you squash

--- a/src/components/StartMenu.tsx
+++ b/src/components/StartMenu.tsx
@@ -8,7 +8,7 @@ export default function StartMenu({ onClose }: { onClose: () => void }) {
 
   return (
     <div
-      className={`absolute bottom-8 left-0 w-48 p-2 bg-[#C0C0C0] ${raised} ${windowShadow} text-sm z-50`}
+      className={`absolute left-0 bottom-[calc(100%-2px)] w-48 p-2 bg-[#C0C0C0] ${raised} ${windowShadow} text-sm z-50`}
     >
       <ul className="space-y-1">
         {START_MENU_APPS.map(app => (

--- a/src/components/Taskbar.tsx
+++ b/src/components/Taskbar.tsx
@@ -1,11 +1,30 @@
 import { useEffect, useMemo, useState } from 'react'
-import { raised, sunken } from '../utils/win95'
+import { raised, sunken, taskbarDivider, taskbarSurface } from '../utils/win95'
 import StartMenu from './StartMenu'
 import Win95Button from './win95/Button'
 import { useWindowManager } from '../contexts/WindowManagerContext'
 
 const getTime = () =>
   new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+
+const GRIP_DOTS = Array.from({ length: 6 }, (_, index) => index)
+
+function StartLogo() {
+  return (
+    <svg
+      viewBox="0 0 14 14"
+      role="presentation"
+      aria-hidden
+      className="h-3.5 w-3.5"
+      shapeRendering="crispEdges"
+    >
+      <rect width="6" height="6" fill="#ff0000" />
+      <rect x="7" width="6" height="6" fill="#00a000" />
+      <rect x="1" y="7" width="6" height="6" fill="#0000ff" />
+      <rect x="8" y="7" width="6" height="6" fill="#ffff00" />
+    </svg>
+  )
+}
 
 export default function Taskbar() {
   const { windows, activeWindowId, toggleMinimize, focusWindow, apps } =
@@ -25,17 +44,37 @@ export default function Taskbar() {
 
   return (
     <div
-      className={`relative h-10 bg-[#C0C0C0] flex items-center px-2 ${sunken}`}
+      className={`relative h-10 w-full bg-[#C0C0C0] px-2 flex items-center gap-2 ${taskbarSurface}`}
     >
       <Win95Button
         onClick={() => setOpen(v => !v)}
-        className={`flex items-center h-7 px-3 gap-2 bg-[#C0C0C0] ${raised} active:${sunken}`}
+        aria-pressed={open}
+        variant={open ? 'sunken' : 'raised'}
+        className="h-9 min-w-[96px] justify-start gap-2 px-3 pr-4 py-0 text-sm font-bold italic leading-none tracking-tight text-black"
       >
-        <span className="w-3 h-3 bg-[#000080]" />
-        <span className="text-sm font-bold">Start</span>
+        <StartLogo />
+        <span className="pt-px">Start</span>
       </Win95Button>
 
-      <div className="flex-1 flex items-center px-2 gap-2 overflow-x-auto">
+      <div aria-hidden className={`h-9 w-[2px] ${taskbarDivider}`} />
+
+      <div
+        className={`flex-1 h-9 flex items-center gap-1 overflow-x-auto overflow-y-hidden px-2 whitespace-nowrap bg-[#BDBDBD] ${sunken}`}
+      >
+        <div
+          aria-hidden
+          className="mr-2 flex h-full flex-shrink-0 items-center pl-1 pr-2"
+        >
+          <div className="grid grid-cols-2 gap-[1px]">
+            {GRIP_DOTS.map(dot => (
+              <span
+                key={dot}
+                className="block h-1 w-1 bg-[#404040] shadow-[1px_1px_0_0_#ffffff]"
+              />
+            ))}
+          </div>
+        </div>
+
         {orderedWindows.map(window => {
           const definition = apps[window.appId]
           const isActive = activeWindowId === window.id && !window.minimized
@@ -50,20 +89,21 @@ export default function Taskbar() {
                   focusWindow(window.id)
                 }
               }}
-              className={`h-7 px-3 flex items-center gap-2 truncate bg-[#C0C0C0] ${raised} ${
-                isActive ? sunken : ''
-              }`}
+              variant={isActive ? 'sunken' : 'raised'}
+              className="h-7 min-w-[140px] shrink-0 justify-start gap-2 truncate px-3 py-0 text-sm leading-tight"
             >
               <span aria-hidden>{definition?.icon ?? '🪟'}</span>
-              <span className="truncate max-w-[12rem] text-left">
-                {window.title}
-              </span>
+              <span className="truncate text-left">{window.title}</span>
             </Win95Button>
           )
         })}
       </div>
 
-      <div className={`h-7 px-3 bg-[#C0C0C0] ${raised} font-mono text-sm`}>
+      <div aria-hidden className={`h-9 w-[2px] ${taskbarDivider}`} />
+
+      <div
+        className={`flex h-9 min-w-[96px] items-center justify-center px-3 text-sm font-normal leading-none font-mono bg-[#C0C0C0] ${raised}`}
+      >
         {time}
       </div>
 

--- a/src/components/win95/Button.tsx
+++ b/src/components/win95/Button.tsx
@@ -1,15 +1,24 @@
 import { ButtonHTMLAttributes } from 'react'
-import { raised } from '../../utils/win95'
+import { raised, sunken } from '../../utils/win95'
+
+type Variant = 'raised' | 'sunken'
 
 type Props = ButtonHTMLAttributes<HTMLButtonElement> & {
   className?: string
+  variant?: Variant
 }
 
-export default function Button({ className = '', ...props }: Props) {
+export default function Button({
+  className = '',
+  variant = 'raised',
+  ...props
+}: Props) {
+  const appearance = variant === 'sunken' ? sunken : raised
+
   return (
     <button
       {...props}
-      className={`flex items-center justify-center bg-[#C0C0C0] ${raised} transition-colors hover:bg-[#A0A0A0] active:bg-[#A0A0A0] focus:outline-none focus-visible:ring-2 focus-visible:ring-black px-3 py-1 ${className}`}
+      className={`flex items-center justify-center bg-[#C0C0C0] ${appearance} transition-colors hover:bg-[#A0A0A0] active:bg-[#A0A0A0] focus:outline-none focus-visible:ring-2 focus-visible:ring-black px-3 py-1 ${className}`}
     />
   )
 }

--- a/src/utils/win95.ts
+++ b/src/utils/win95.ts
@@ -4,3 +4,7 @@ export const sunken =
   'border-2 border-t-gray-500 border-l-gray-500 border-b-white border-r-white'
 export const windowShadow =
   'shadow-[inset_-2px_-2px_0_0_rgba(0,0,0,0.55),inset_2px_2px_0_0_rgba(255,255,255,0.8)]'
+export const taskbarSurface =
+  'shadow-[inset_0_1px_0_0_#ffffff,inset_0_2px_0_0_#dfdfdf,inset_0_-1px_0_0_#404040,inset_0_-2px_0_0_#808080,inset_1px_0_0_#dfdfdf,inset_2px_0_0_#ffffff,inset_-1px_0_0_#404040,inset_-2px_0_0_#808080]'
+export const taskbarDivider =
+  'bg-[#9f9f9f] shadow-[inset_-1px_0_0_#ffffff,inset_1px_0_0_#404040]'


### PR DESCRIPTION
## Summary
- restyled the taskbar with an authentic Windows 95 start button, separators, recessed window list, and updated tray clock
- anchored the start menu to the taskbar edge and added a reusable button variant for sunken states
- noted the pixel-perfect taskbar in the README and extracted taskbar surface tokens

## Testing
- npm run format
- npm run lint
- npm test *(fails: node: bad option: --experimental-transform-types)*

------
https://chatgpt.com/codex/tasks/task_e_68c886efdd98832aa80b90f5186c6230