### PR TITLE
Restyle taskbar to match Windows 95

### DIFF
--- a/src/components/StartMenu.tsx
+++ b/src/components/StartMenu.tsx
@@ -1,34 +1,46 @@
-import { raised, sunken, windowShadow } from '../utils/win95'
+import { raised, windowShadow } from '../utils/win95'
 import { START_MENU_APPS } from '../utils/window-apps'
 import { useWindowManager } from '../contexts/WindowManagerContext'
 
 export default function StartMenu({ onClose }: { onClose: () => void }) {
   const { openWindow } = useWindowManager()
-  const itemClass = `block w-full text-left px-2 py-1 ${raised} bg-[#E0E0E0] hover:${sunken}`
+  const itemClass =
+    'flex w-full items-center gap-2 px-3 py-2 text-left text-black hover:bg-[#000080] hover:text-white focus-visible:bg-[#000080] focus-visible:text-white'
 
   return (
     <div
-      className={`absolute bottom-8 left-0 w-48 p-2 bg-[#C0C0C0] ${raised} ${windowShadow} text-sm z-50`}
+      className={`absolute bottom-[calc(100%+6px)] left-0 flex w-64 bg-[#C0C0C0] ${raised} ${windowShadow} text-sm z-50`}
     >
-      <ul className="space-y-1">
-        {START_MENU_APPS.map(app => (
-          <li key={app.id}>
-            <button
-              type="button"
-              className={itemClass}
-              onClick={() => {
-                openWindow(app.id)
-                onClose()
-              }}
-            >
-              <span className="mr-2" aria-hidden>
-                {app.icon}
-              </span>
-              {app.title}
-            </button>
-          </li>
-        ))}
-      </ul>
+      <div className="flex flex-col items-center justify-between bg-gradient-to-b from-[#000080] via-[#000060] to-[#000040] px-3 py-4 text-white">
+        <span className="grid h-6 w-6 grid-cols-2 grid-rows-2 gap-[1px]">
+          <span className="bg-[#01017A]" />
+          <span className="bg-[#D80000]" />
+          <span className="bg-[#008001]" />
+          <span className="bg-[#F4F100]" />
+        </span>
+        <span className="-rotate-90 origin-bottom-left whitespace-nowrap text-lg font-bold tracking-[0.35em]">
+          Windows 95
+        </span>
+      </div>
+      <div className="flex-1 p-3">
+        <ul className="space-y-1">
+          {START_MENU_APPS.map(app => (
+            <li key={app.id}>
+              <button
+                type="button"
+                className={itemClass}
+                onClick={() => {
+                  openWindow(app.id)
+                  onClose()
+                }}
+              >
+                <span aria-hidden>{app.icon}</span>
+                {app.title}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
     </div>
   )
 }

--- a/src/components/Taskbar.tsx
+++ b/src/components/Taskbar.tsx
@@ -7,6 +7,53 @@ import { useWindowManager } from '../contexts/WindowManagerContext'
 const getTime = () =>
   new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
 
+function SpeakerIcon() {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      className="h-4 w-4 fill-black"
+      aria-hidden
+      focusable="false"
+    >
+      <path d="M2.75 6H5.5L8.5 3.5v9L5.5 10H2.75z" />
+      <path
+        d="M11.75 5.25c1.75 1.75 1.75 4.75 0 6.5"
+        fill="none"
+        stroke="black"
+        strokeWidth="1.5"
+        strokeLinecap="square"
+      />
+      <path
+        d="M13.75 3.25c2.5 2.5 2.5 7 0 9.5"
+        fill="none"
+        stroke="black"
+        strokeWidth="1.5"
+        strokeLinecap="square"
+      />
+    </svg>
+  )
+}
+
+function NetworkIcon() {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      className="h-4 w-4 fill-black"
+      aria-hidden
+      focusable="false"
+    >
+      <path d="M2 12h3v2H2zM6.5 9h3v5h-3zM11 6h3v8h-3z" />
+      <path
+        d="M2 7.5 8 3.5l6 4"
+        fill="none"
+        stroke="black"
+        strokeWidth="1.25"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}
+
 export default function Taskbar() {
   const { windows, activeWindowId, toggleMinimize, focusWindow, apps } =
     useWindowManager()
@@ -24,55 +71,108 @@ export default function Taskbar() {
   )
 
   return (
-    <div
-      className={`relative h-10 bg-[#C0C0C0] flex items-center px-2 ${sunken}`}
-    >
-      <Win95Button
-        onClick={() => setOpen(v => !v)}
-        className={`flex items-center h-7 px-3 gap-2 bg-[#C0C0C0] ${raised} active:${sunken}`}
-      >
-        <span className="w-3 h-3 bg-[#000080]" />
-        <span className="text-sm font-bold">Start</span>
-      </Win95Button>
-
-      <div className="flex-1 flex items-center px-2 gap-2 overflow-x-auto">
-        {orderedWindows.map(window => {
-          const definition = apps[window.appId]
-          const isActive = activeWindowId === window.id && !window.minimized
-
-          return (
-            <Win95Button
-              key={window.id}
-              onClick={() => {
-                if (window.minimized || isActive) {
-                  toggleMinimize(window.id)
-                } else {
-                  focusWindow(window.id)
-                }
-              }}
-              className={`h-7 px-3 flex items-center gap-2 truncate bg-[#C0C0C0] ${raised} ${
-                isActive ? sunken : ''
-              }`}
-            >
-              <span aria-hidden>{definition?.icon ?? '🪟'}</span>
-              <span className="truncate max-w-[12rem] text-left">
-                {window.title}
-              </span>
-            </Win95Button>
-          )
-        })}
-      </div>
-
-      <div className={`h-7 px-3 bg-[#C0C0C0] ${raised} font-mono text-sm`}>
-        {time}
-      </div>
-
+    <footer className="relative select-none text-[13px] text-black">
       {open && (
-        <>
-          <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />
-          <StartMenu onClose={() => setOpen(false)} />
-        </>
+        <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />
       )}
-    </div>
+      <div className="h-[2px] w-full bg-white" />
+      <div className="h-[2px] w-full bg-[#808080]" />
+      <div className="relative z-10 flex h-12 items-center gap-3 border-2 border-b-[#404040] border-l-white border-r-[#404040] border-t-white bg-[#BDBDBD] px-2 font-['MS_Sans_Serif','Tahoma',sans-serif]">
+        <div className="relative">
+          <Win95Button
+            aria-expanded={open}
+            aria-haspopup="menu"
+            onClick={() => setOpen(value => !value)}
+            className={`h-9 gap-3 px-4 py-[3px] text-[13px] font-semibold leading-none tracking-tight text-black ${
+              open ? sunken : ''
+            } justify-start`}
+          >
+            <span className="grid h-4 w-4 grid-cols-2 grid-rows-2 gap-[1px]">
+              <span className="bg-[#01017A]" />
+              <span className="bg-[#D80000]" />
+              <span className="bg-[#008001]" />
+              <span className="bg-[#F4F100]" />
+            </span>
+            <span className="[text-shadow:1px_1px_0_#FFFFFF]">Start</span>
+          </Win95Button>
+          {open && <StartMenu onClose={() => setOpen(false)} />}
+        </div>
+
+        <div className="flex h-9 flex-1 items-stretch gap-2">
+          <div className="flex h-full flex-col justify-center">
+            <div className="h-full w-[1px] bg-white" />
+            <div className="h-full w-[1px] bg-[#808080]" />
+          </div>
+
+          <div
+            className={`flex flex-1 items-center gap-1 overflow-x-auto px-1 ${sunken} bg-[#BDBDBD]`}
+          >
+            {orderedWindows.map(window => {
+              const definition = apps[window.appId]
+              const isActive = activeWindowId === window.id && !window.minimized
+
+              return (
+                <Win95Button
+                  key={window.id}
+                  title={window.title}
+                  onClick={() => {
+                    if (window.minimized || isActive) {
+                      toggleMinimize(window.id)
+                    } else {
+                      focusWindow(window.id)
+                    }
+                  }}
+                  className={`h-7 min-w-[7rem] justify-start gap-2 truncate px-3 py-[2px] text-left text-[13px] font-normal ${
+                    isActive ? sunken : ''
+                  }`}
+                >
+                  <span aria-hidden className="text-base">
+                    {definition?.icon ?? '🪟'}
+                  </span>
+                  <span className="truncate">{window.title}</span>
+                </Win95Button>
+              )
+            })}
+          </div>
+
+          <div className="flex h-full flex-col justify-center">
+            <div className="h-full w-[1px] bg-white" />
+            <div className="h-full w-[1px] bg-[#808080]" />
+          </div>
+
+          <div
+            className={`flex items-center gap-3 ${sunken} h-9 px-3 pr-4 text-[12px]`}
+          >
+            <div className="flex items-center gap-2">
+              <div
+                className={`flex h-6 w-6 items-center justify-center bg-[#C0C0C0] ${raised}`}
+                role="img"
+                aria-label="Volume"
+              >
+                <SpeakerIcon />
+              </div>
+              <div
+                className={`flex h-6 w-6 items-center justify-center bg-[#C0C0C0] ${raised}`}
+                role="img"
+                aria-label="Network"
+              >
+                <NetworkIcon />
+              </div>
+            </div>
+
+            <div className="flex h-6 flex-col justify-between">
+              <div className="h-[1px] w-full bg-[#808080]" />
+              <div className="h-[1px] w-full bg-white" />
+            </div>
+
+            <div
+              className={`flex h-6 items-center justify-center px-3 font-mono text-sm leading-none bg-[#C0C0C0] ${raised}`}
+            >
+              {time}
+            </div>
+          </div>
+        </div>
+      </div>
+    </footer>
   )
 }


### PR DESCRIPTION
## Summary
- reshape the desktop taskbar to faithfully mimic the Windows 95 layout with start button, task list, tray groove, and clock treatments
- refresh the start menu styling with the Windows 95 branding strip and hover behavior so it aligns with the new bar

## Testing
- npm run format
- npm run lint
- npm test *(fails: current Node version does not recognise required experimental flags)*

------
https://chatgpt.com/codex/tasks/task_e_68c886efdd98832aa80b90f5186c6230