### PR TITLE
Adopt React95 components

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ This is a "bug bounty hackathon" project that ironically has more bugs than it f
 - 📊 **Dashboard with Fancy Charts**: D3.js charts now sport gradients, grids, and zoom
 - 🏆 **Leaderboard System**: Compete with yourself since you're probably the only user
 - 🎨 **Windows 95 UI**: Nothing says "modern web development" like nostalgic 30-year-old design
+- 🧱 **React95 Powered Shell**: Authentic Windows 95 components, themes, and menus delivered straight from the React95 design system
 - 🪟 **Pixel-Perfect Window Controls**: Title bars now rock the classic `_`, `□`, and `X` glyphs straight out of Windows 95
 - 🖱️ **Authentic Desktop Shell**: Draggable, resizable windows with minimize/maximize controls, a living taskbar, and a Start menu that launches every feature
 - 🗃️ **Zustand State Management**: Because Redux wasn't complicated enough, we needed something "simpler"
@@ -88,6 +89,7 @@ This project showcases the fine art of using 30 dependencies to accomplish what 
 - **TypeScript**: Because JavaScript wasn't confusing enough
 - **Tailwind CSS**: Why write 10 lines of CSS when you can write 100 class names?
 - **Radix UI**: Premium headless components for basic HTML elements
+- **React95 + styled-components**: A full Windows 95 component library and theme engine powering the desktop chrome
 - **D3.js**: Nuclear-powered charting library for displaying 5 data points
 - **Framer Motion**: Hollywood-grade animations for hover effects
 - **Zustand**: State management for 3 variables that could've been `useState`

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,8 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-rnd": "^10.5.2",
+        "react95": "^4.0.0",
+        "styled-components": "^6.1.19",
         "tailwind-merge": "^3.3.1",
         "tailwindcss": "^4.1.11",
         "tailwindcss-animate": "^1.0.7",
@@ -32,6 +34,7 @@
         "@types/d3": "^7.4.3",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
+        "@types/styled-components": "^5.1.34",
         "@vitejs/plugin-react": "^4.6.0",
         "eslint": "^9.29.0",
         "eslint-plugin-react-hooks": "^5.2.0",
@@ -339,23 +342,25 @@
       }
     },
     "node_modules/@emotion/is-prop-valid": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
-      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
+      "integrity": "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "@emotion/memoize": "0.7.4"
+        "@emotion/memoize": "^0.8.1"
       }
     },
     "node_modules/@emotion/memoize": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
+      "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==",
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.4",
@@ -2364,6 +2369,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz",
+      "integrity": "sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hoist-non-react-statics": "^3.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -2390,6 +2408,24 @@
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
+    },
+    "node_modules/@types/styled-components": {
+      "version": "5.1.34",
+      "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.34.tgz",
+      "integrity": "sha512-mmiVvwpYklFIv9E8qfxuPyIt/OuyIrn6gMOAMOFUO3WJfSrSE+sGUoa4PiZj77Ut7bKZpaa6o1fBKS/4TOEvnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "*",
+        "@types/react": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/stylis": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.5.tgz",
+      "integrity": "sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.35.0",
@@ -2832,6 +2868,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001718",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz",
@@ -2958,11 +3003,30 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3": {
@@ -3921,6 +3985,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -4675,6 +4749,12 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "license": "MIT"
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -4834,6 +4914,27 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "license": "0BSD"
     },
+    "node_modules/react95": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/react95/-/react95-4.0.0.tgz",
+      "integrity": "sha512-C/2Ecws+ShHMJa3/ki6d3ufCukEYyZ+up45NJhX+uecFh5sXNdkEX8bPZ4pKTGl0mSTMkiCJTGOJB1Gmf1W3dA==",
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://www.paypal.me/react95"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/arturbien"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16.8.0",
+        "react-dom": ">= 16.8.0",
+        "styled-components": ">= 5.3.3"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -4952,6 +5053,12 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "license": "MIT"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -4996,6 +5103,74 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/styled-components": {
+      "version": "6.1.19",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.19.tgz",
+      "integrity": "sha512-1v/e3Dl1BknC37cXMhwGomhO8AkYmN41CqyX9xhUDxry1ns3BFQy2lLDRQXJRdVVWB9OHemv/53xaStimvWyuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/is-prop-valid": "1.2.2",
+        "@emotion/unitless": "0.8.1",
+        "@types/stylis": "4.2.5",
+        "css-to-react-native": "3.2.0",
+        "csstype": "3.1.3",
+        "postcss": "8.4.49",
+        "shallowequal": "1.1.0",
+        "stylis": "4.3.2",
+        "tslib": "2.6.2"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/styled-components"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0",
+        "react-dom": ">= 16.8.0"
+      }
+    },
+    "node_modules/styled-components/node_modules/postcss": {
+      "version": "8.4.49",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
+      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.7",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/styled-components/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "license": "0BSD"
+    },
+    "node_modules/stylis": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.2.tgz",
+      "integrity": "sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg==",
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-rnd": "^10.5.2",
+    "react95": "^4.0.0",
+    "styled-components": "^6.1.19",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.11",
     "tailwindcss-animate": "^1.0.7",
@@ -36,6 +38,7 @@
   "devDependencies": {
     "@eslint/js": "^9.29.0",
     "@types/d3": "^7.4.3",
+    "@types/styled-components": "^5.1.34",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",

--- a/src/components/DesktopWindow.tsx
+++ b/src/components/DesktopWindow.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from 'react'
 import { Rnd } from 'react-rnd'
+import { WindowContent } from 'react95'
 import Window from './win95/Window'
 import TitleBar from './win95/TitleBar'
 import Win95Button from './win95/Button'
@@ -11,8 +12,6 @@ import {
 import { useWindowManager } from '../contexts/WindowManagerContext'
 import { WINDOW_APPS } from '../utils/window-apps'
 import type { WindowSize, WindowState } from '../types/window'
-
-const CONTROL_BUTTON_CLASS = 'h-6 w-6 p-0 flex items-center justify-center'
 
 type Props = {
   windowState: WindowState
@@ -28,6 +27,7 @@ export default function DesktopWindow({ windowState, containerSize }: Props) {
     setWindowPosition,
     setWindowSize,
     setWindowTitle,
+    activeWindowId,
   } = useWindowManager()
 
   const definition = WINDOW_APPS[windowState.appId]
@@ -67,37 +67,44 @@ export default function DesktopWindow({ windowState, containerSize }: Props) {
       className={`absolute ${windowState.minimized ? 'hidden' : ''}`}
       style={{ zIndex: windowState.zIndex }}
     >
-      <Window className="h-full">
+      <Window className="h-full flex flex-col" shadow>
         <TitleBar
           title={windowState.title}
+          active={activeWindowId === windowState.id && !windowState.minimized}
           onDoubleClick={handleMaximize}
           controls={
-            <div className="flex gap-px">
+            <div className="flex gap-1">
               <Win95Button
+                square
+                size="sm"
                 onClick={() => toggleMinimize(windowState.id)}
                 aria-label="Minimize"
-                className={CONTROL_BUTTON_CLASS}
+                type="button"
               >
                 <Win95MinimizeIcon />
               </Win95Button>
               <Win95Button
+                square
+                size="sm"
                 onClick={handleMaximize}
                 aria-label={windowState.maximized ? 'Restore' : 'Maximize'}
-                className={CONTROL_BUTTON_CLASS}
+                type="button"
               >
                 <Win95MaximizeIcon />
               </Win95Button>
               <Win95Button
+                square
+                size="sm"
                 onClick={() => closeWindow(windowState.id)}
                 aria-label="Close"
-                className={CONTROL_BUTTON_CLASS}
+                type="button"
               >
                 <Win95CloseIcon />
               </Win95Button>
             </div>
           }
         />
-        <div className="bg-[#E0E0E0] flex-1 overflow-hidden p-3">
+        <WindowContent className="flex-1 overflow-hidden">
           <Suspense fallback={<div className="p-4">Loading...</div>}>
             <Component
               windowId={windowState.id}
@@ -105,7 +112,7 @@ export default function DesktopWindow({ windowState, containerSize }: Props) {
               setTitle={title => setWindowTitle(windowState.id, title)}
             />
           </Suspense>
-        </div>
+        </WindowContent>
       </Window>
     </Rnd>
   )

--- a/src/components/StartMenu.tsx
+++ b/src/components/StartMenu.tsx
@@ -1,34 +1,31 @@
-import { raised, sunken, windowShadow } from '../utils/win95'
+import { MenuList, MenuListItem, Window } from 'react95'
 import { START_MENU_APPS } from '../utils/window-apps'
 import { useWindowManager } from '../contexts/WindowManagerContext'
 
 export default function StartMenu({ onClose }: { onClose: () => void }) {
   const { openWindow } = useWindowManager()
-  const itemClass = `block w-full text-left px-2 py-1 ${raised} bg-[#E0E0E0] hover:${sunken}`
 
   return (
-    <div
-      className={`absolute left-[4px] bottom-[calc(100%+4px)] w-48 p-2 bg-[#C0C0C0] ${raised} ${windowShadow} text-sm z-50`}
+    <Window
+      className="absolute left-[4px] bottom-[calc(100%+4px)] w-52 z-50"
+      shadow
     >
-      <ul className="space-y-1">
+      <MenuList fullWidth>
         {START_MENU_APPS.map(app => (
-          <li key={app.id}>
-            <button
-              type="button"
-              className={itemClass}
-              onClick={() => {
-                openWindow(app.id)
-                onClose()
-              }}
-            >
-              <span className="mr-2" aria-hidden>
-                {app.icon}
-              </span>
-              {app.title}
-            </button>
-          </li>
+          <MenuListItem
+            key={app.id}
+            onClick={() => {
+              openWindow(app.id)
+              onClose()
+            }}
+          >
+            <div className="flex w-full items-center gap-2">
+              <span aria-hidden>{app.icon}</span>
+              <span className="flex-1 text-left">{app.title}</span>
+            </div>
+          </MenuListItem>
         ))}
-      </ul>
-    </div>
+      </MenuList>
+    </Window>
   )
 }

--- a/src/components/win95/Button.tsx
+++ b/src/components/win95/Button.tsx
@@ -1,15 +1,10 @@
-import { ButtonHTMLAttributes } from 'react'
-import { raised } from '../../utils/win95'
+import { forwardRef } from 'react'
+import { Button as React95Button, type ButtonProps } from 'react95'
 
-type Props = ButtonHTMLAttributes<HTMLButtonElement> & {
-  className?: string
-}
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  function Button(props, ref) {
+    return <React95Button ref={ref} {...props} />
+  }
+)
 
-export default function Button({ className = '', ...props }: Props) {
-  return (
-    <button
-      {...props}
-      className={`flex items-center justify-center bg-[#C0C0C0] ${raised} transition-colors hover:bg-[#A0A0A0] active:bg-[#A0A0A0] focus:outline-none focus-visible:ring-2 focus-visible:ring-black px-3 py-1 ${className}`}
-    />
-  )
-}
+export default Button

--- a/src/components/win95/Input.tsx
+++ b/src/components/win95/Input.tsx
@@ -1,21 +1,11 @@
-import { InputHTMLAttributes, forwardRef } from 'react'
-import { sunken } from '../../utils/win95'
+import { forwardRef } from 'react'
+import { TextInput, type TextInputProps } from 'react95'
 
-type Props = InputHTMLAttributes<HTMLInputElement> & {
-  className?: string
-}
-
-const Input = forwardRef<HTMLInputElement, Props>(function Input(
-  { className = '', ...props },
-  ref
-) {
-  return (
-    <input
-      ref={ref}
-      {...props}
-      className={`bg-[#E0E0E0] ${sunken} px-2 py-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-black ${className}`}
-    />
-  )
+const Input = forwardRef<
+  HTMLInputElement | HTMLTextAreaElement,
+  TextInputProps
+>(function Input(props, ref) {
+  return <TextInput ref={ref} {...props} />
 })
 
 export default Input

--- a/src/components/win95/Panel.tsx
+++ b/src/components/win95/Panel.tsx
@@ -1,18 +1,19 @@
-import { PropsWithChildren } from 'react'
-import { raised, sunken } from '../../utils/win95'
+import { forwardRef, type PropsWithChildren } from 'react'
+import { Frame, type FrameProps } from 'react95'
 
 type Props = {
   variant?: 'sunken' | 'raised'
-  className?: string
-}
+} & Omit<FrameProps, 'variant'>
 
-export default function Panel({
-  children,
-  variant = 'sunken',
-  className = '',
-}: PropsWithChildren<Props>) {
-  const border = variant === 'sunken' ? sunken : raised
-  return (
-    <div className={`bg-[#E0E0E0] ${border} p-2 ${className}`}>{children}</div>
-  )
-}
+const Panel = forwardRef<HTMLDivElement, PropsWithChildren<Props>>(
+  function Panel({ variant = 'sunken', children, ...props }, ref) {
+    const mappedVariant = variant === 'sunken' ? 'well' : 'window'
+    return (
+      <Frame ref={ref} variant={mappedVariant} {...props}>
+        {children}
+      </Frame>
+    )
+  }
+)
+
+export default Panel

--- a/src/components/win95/Select.tsx
+++ b/src/components/win95/Select.tsx
@@ -1,19 +1,68 @@
-import { SelectHTMLAttributes, forwardRef } from 'react'
-import { sunken } from '../../utils/win95'
+import {
+  Children,
+  forwardRef,
+  isValidElement,
+  type ChangeEvent,
+  type ReactElement,
+  type ReactNode,
+} from 'react'
+import {
+  SelectNative,
+  type SelectNativeProps,
+  type SelectOption,
+} from 'react95'
 
-type Props = SelectHTMLAttributes<HTMLSelectElement> & {
-  className?: string
+type NativeChangeHandler = NonNullable<SelectNativeProps['onChange']>
+type LegacyChangeHandler = (event: ChangeEvent<HTMLSelectElement>) => void
+
+type Props = Omit<SelectNativeProps, 'options' | 'onChange'> & {
+  options?: SelectOption<string>[]
+  children?: ReactNode
+  onChange?: LegacyChangeHandler | NativeChangeHandler
 }
 
 const Select = forwardRef<HTMLSelectElement, Props>(function Select(
-  { className = '', ...props },
+  { options, children, onChange, ...props },
   ref
 ) {
+  const derivedOptions: SelectOption<string>[] =
+    options ??
+    Children.toArray(children)
+      .filter(
+        (child): child is ReactElement<{ value?: string }> =>
+          isValidElement(child) && child.type === 'option'
+      )
+      .map(child => ({
+        value:
+          child.props.value ??
+          (typeof child.props.children === 'string'
+            ? child.props.children
+            : ''),
+        label:
+          typeof child.props.children === 'string'
+            ? child.props.children
+            : (child.props.value ?? ''),
+      }))
+
+  const handleChange: NativeChangeHandler = (selected, details) => {
+    if (!onChange) return
+
+    if (onChange.length >= 2) {
+      ;(onChange as NativeChangeHandler)(selected, details)
+      return
+    }
+
+    ;(onChange as LegacyChangeHandler)(
+      details.fromEvent as ChangeEvent<HTMLSelectElement>
+    )
+  }
+
   return (
-    <select
+    <SelectNative
       ref={ref}
+      options={derivedOptions}
+      onChange={onChange ? handleChange : undefined}
       {...props}
-      className={`bg-[#E0E0E0] ${sunken} px-2 py-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-black ${className}`}
     />
   )
 })

--- a/src/components/win95/TitleBar.tsx
+++ b/src/components/win95/TitleBar.tsx
@@ -1,10 +1,12 @@
-import { ReactNode } from 'react'
+import type { ReactNode } from 'react'
+import { WindowHeader } from 'react95'
 
 type Props = {
   title: string
   controls?: ReactNode
   className?: string
   onDoubleClick?: () => void
+  active?: boolean
 }
 
 export default function TitleBar({
@@ -12,16 +14,16 @@ export default function TitleBar({
   controls,
   className = '',
   onDoubleClick,
+  active = true,
 }: Props) {
   return (
-    <div
-      className={`win95-title-bar h-8 select-none border-b-2 border-b-white bg-[#000080] px-2 text-white z-10 ${className}`}
+    <WindowHeader
+      active={active}
+      className={`win95-title-bar flex items-center justify-between gap-2 pr-1 ${className}`}
       onDoubleClick={onDoubleClick}
     >
-      <div className="flex h-full items-center justify-between">
-        <span className="font-bold tracking-wider">{title}</span>
-        {controls}
-      </div>
-    </div>
+      <span className="truncate">{title}</span>
+      {controls}
+    </WindowHeader>
   )
 }

--- a/src/components/win95/Window.tsx
+++ b/src/components/win95/Window.tsx
@@ -1,19 +1,16 @@
-import { PropsWithChildren } from 'react'
-import { raised, windowShadow } from '../../utils/win95'
+import { forwardRef, type PropsWithChildren } from 'react'
+import { Window as React95Window, type WindowProps } from 'react95'
 
-type Props = {
-  className?: string
-}
+type Props = WindowProps
 
-export default function Window({
-  children,
-  className = '',
-}: PropsWithChildren<Props>) {
-  return (
-    <div
-      className={`w-full bg-[#C0C0C0] ${raised} ${windowShadow} flex flex-col ${className}`}
-    >
-      {children}
-    </div>
-  )
-}
+const Window = forwardRef<HTMLDivElement, PropsWithChildren<Props>>(
+  function Window({ children, ...props }, ref) {
+    return (
+      <React95Window ref={ref} {...props}>
+        {children}
+      </React95Window>
+    )
+  }
+)
+
+export default Window

--- a/src/index.css
+++ b/src/index.css
@@ -6,14 +6,4 @@
   #root {
     height: 100%;
   }
-
-  button {
-    @apply bg-[#C0C0C0] transition-colors hover:bg-[#A0A0A0] active:bg-[#A0A0A0] focus:outline-none focus-visible:ring-2 focus-visible:ring-black px-3 py-1;
-  }
-
-  input,
-  select,
-  textarea {
-    @apply bg-[#E0E0E0] px-2 py-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-black;
-  }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,39 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
+import { ThemeProvider, createGlobalStyle } from 'styled-components'
+import { styleReset } from 'react95'
+import original from 'react95/dist/themes/original'
 import App from './App'
 import './index.css'
 
+const GlobalStyles = createGlobalStyle`
+  ${styleReset}
+
+  *, *::before, *::after {
+    box-sizing: border-box;
+  }
+
+  body {
+    background-color: #008080;
+    background-image:
+      radial-gradient(rgba(255, 255, 255, 0.12) 1px, transparent 1px),
+      radial-gradient(rgba(0, 0, 0, 0.08) 1px, transparent 1px);
+    background-size: 8px 8px;
+    background-position: 0 0, 4px 4px;
+    color: #000;
+    font-family: 'ms_sans_serif', 'Tahoma', sans-serif;
+  }
+
+  a {
+    color: inherit;
+  }
+`
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <ThemeProvider theme={original}>
+      <GlobalStyles />
+      <App />
+    </ThemeProvider>
   </React.StrictMode>
 )


### PR DESCRIPTION
## Summary
- wrap the app in React95 global styles and theme provider for consistent Windows 95 theming
- replace bespoke Win95 primitives with React95 Button, Input, Panel, Select, TitleBar and Window components and update desktop/start menu chrome
- document the React95 integration and add the new dependencies

## Testing
- npm run format
- npm run lint
- npm test *(fails: node: bad option: --experimental-transform-types)*

------
https://chatgpt.com/codex/tasks/task_e_68c893fa2700832a9c51a9a849c940ba