### PR TITLE
Rebuild Windows 95 start menu and taskbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ This is a "bug bounty hackathon" project that ironically has more bugs than it f
 - 🎨 **Tailwind CSS**: 47KB of utility classes to style 3 buttons
 - 🎬 **Framer Motion**: Animated everything because static websites are for quitters
 - 🖥️ **Windows 95 Taskbar**: Pixel-perfect Start button, beveled task list, and system tray clock straight from 1995
-- 📂 **Start Menu**: Authentic start menu for quick navigation
+- 📂 **Start Menu**: Rebuilt with the teal sidebar, beveled casing, and Start button alignment from classic Windows 95 for quick navigation
 - 🗂️ **Desktop Shortcuts Everywhere**: Every page now shows up on the desktop for
   quick double-click access
 - 🔍 **Search & Filter**: Hunt bugs and leaderboard entries like a pro

--- a/package-lock.json
+++ b/package-lock.json
@@ -5285,17 +5285,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/use-sync-external-store": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
-      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/uuid": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",

--- a/src/components/StartMenu.tsx
+++ b/src/components/StartMenu.tsx
@@ -1,32 +1,89 @@
-import { MenuList, MenuListItem, Window } from 'react95'
+import { useEffect } from 'react'
 import { START_MENU_APPS } from '../utils/window-apps'
 import { useWindowManager } from '../contexts/WindowManagerContext'
 
-export default function StartMenu({ onClose }: { onClose: () => void }) {
+type StartMenuProps = {
+  anchorRect: DOMRect | null
+  onClose: () => void
+}
+
+const MENU_WIDTH = 260
+
+export default function StartMenu({ anchorRect, onClose }: StartMenuProps) {
   const { openWindow } = useWindowManager()
 
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose()
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [onClose])
+
+  const viewportWidth = typeof window !== 'undefined' ? window.innerWidth : 1024
+  const viewportHeight =
+    typeof window !== 'undefined' ? window.innerHeight : 768
+
+  const anchorLeft = anchorRect?.left ?? 8
+  const anchorTop = anchorRect?.top ?? viewportHeight - 40
+
+  const left = Math.min(anchorLeft, viewportWidth - MENU_WIDTH - 12)
+  const bottom = Math.max(viewportHeight - anchorTop + 2, 8)
+
   return (
-    <Window
-      className="absolute left-[4px] bottom-[calc(100%+4px)] z-50 w-48 p-0"
-      shadow
+    <div
+      className="pointer-events-auto fixed z-50 w-[260px] text-[13px]"
+      style={{ left, bottom }}
+      role="menu"
+      aria-label="Start menu"
     >
-      <MenuList className="p-2" fullWidth>
-        {START_MENU_APPS.map(app => (
-          <MenuListItem
-            key={app.id}
-            as="button"
-            type="button"
-            onClick={() => {
-              openWindow(app.id)
-              onClose()
-            }}
-            className="flex w-full items-center gap-2 px-2 py-1 text-left"
-          >
-            <span aria-hidden>{app.icon}</span>
-            <span className="truncate">{app.title}</span>
-          </MenuListItem>
-        ))}
-      </MenuList>
-    </Window>
+      <div className="start-menu-shadow border-t border-l border-white border-b-[2px] border-r-[2px] border-[#404040] bg-[#C0C0C0] text-black">
+        <div className="flex">
+          <div className="start-menu__brand flex w-[36px] items-end justify-center bg-gradient-to-b from-[#00007B] via-[#008080] to-[#4EA0C6] text-white">
+            <span className="start-menu__brand-text">Windows 95</span>
+          </div>
+          <div className="flex-1 border-l border-[#808080] bg-[#C0C0C0] p-1">
+            <ul className="flex flex-col gap-1">
+              {START_MENU_APPS.map(item => (
+                <li key={item.id}>
+                  <StartMenuItem
+                    icon={item.icon}
+                    title={item.title}
+                    onSelect={() => {
+                      openWindow(item.id)
+                      onClose()
+                    }}
+                  />
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+type StartMenuItemProps = {
+  icon: string
+  title: string
+  onSelect: () => void
+}
+
+function StartMenuItem({ icon, title, onSelect }: StartMenuItemProps) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className="flex h-8 w-full items-center gap-3 truncate border-t border-l border-white border-b border-r border-[#808080] bg-[#C0C0C0] px-3 text-left font-['MS_Sans_Serif','Tahoma',sans-serif] text-[13px] font-semibold text-black transition-colors hover:bg-[#000080] hover:text-white focus:outline-none focus-visible:bg-[#000080] focus-visible:text-white"
+    >
+      <span aria-hidden className="text-lg">
+        {icon}
+      </span>
+      <span className="truncate">{title}</span>
+    </button>
   )
 }

--- a/src/components/Taskbar.tsx
+++ b/src/components/Taskbar.tsx
@@ -1,5 +1,12 @@
-import { useEffect, useMemo, useState } from 'react'
-import { Button, Frame } from 'react95'
+import clsx from 'clsx'
+import {
+  forwardRef,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import StartMenu from './StartMenu'
 import { useWindowManager } from '../contexts/WindowManagerContext'
 
@@ -14,40 +21,51 @@ type StartButtonProps = {
   onClick: () => void
 }
 
-function StartButton({ open, onClick }: StartButtonProps) {
-  return (
-    <Button
-      onClick={onClick}
-      active={open}
-      primary
-      className="flex h-9 items-center gap-2 px-4 text-[13px] font-semibold tracking-tight"
-    >
-      <WindowsLogo className="h-4 w-4" />
-      <span className="tracking-[0.02em]">Start</span>
-    </Button>
-  )
-}
+const StartButton = forwardRef<HTMLButtonElement, StartButtonProps>(
+  ({ open, onClick }, ref) => {
+    return (
+      <button
+        ref={ref}
+        type="button"
+        onClick={onClick}
+        aria-pressed={open}
+        className={clsx(
+          'flex h-[32px] items-center gap-2 px-4 text-[13px] font-semibold tracking-tight text-black transition-colors',
+          "font-['MS_Sans_Serif','Tahoma',sans-serif]",
+          open
+            ? 'border-t-[2px] border-l-[2px] border-[#404040] border-b border-r border-white bg-[#9C9C9C] shadow-[inset_1px_1px_0_0_#cfcfcf,inset_-1px_-1px_0_0_#707070]'
+            : 'border-t-[2px] border-l-[2px] border-white border-b border-r border-[#404040] bg-[#C0C0C0] shadow-[inset_-1px_-1px_0_0_#808080,inset_1px_1px_0_0_#dfdfdf] hover:bg-[#d6d6d6]'
+        )}
+      >
+        <Windows95Logo className="h-5 w-5" />
+        <span className="tracking-[0.03em]">Start</span>
+      </button>
+    )
+  }
+)
 
-function WindowsLogo({ className = '' }: { className?: string }) {
+StartButton.displayName = 'StartButton'
+
+function Windows95Logo({ className = '' }: { className?: string }) {
   return (
     <svg
       className={className}
-      viewBox="0 0 28 28"
+      viewBox="0 0 26 26"
       role="presentation"
       aria-hidden="true"
       focusable="false"
     >
-      <path d="M1 6.5L12.5 4v7L1 12.5V6.5Z" fill="#f35325" />
-      <path d="M14 3.5L27 1v10.5L14 11.5V3.5Z" fill="#07a6f0" />
-      <path d="M1 14L12.5 15.5v7L1 19.5V14Z" fill="#ffba08" />
-      <path d="M14 16l13 1.5V27L14 24.5V16Z" fill="#00b050" />
+      <path d="M1 8L9 6.8V12.5L1 13.8V8Z" fill="#d40000" />
+      <path d="M11 6.3L25 4V12.8L11 11.2V6.3Z" fill="#00a2e8" />
+      <path d="M1 15.4L9 16.3V22L1 20.8V15.4Z" fill="#ffc20e" />
+      <path d="M11 17L25 18.2V26L11 23.8V17Z" fill="#00a651" />
     </svg>
   )
 }
 
 function Divider() {
   return (
-    <div className="flex h-9 w-[3px] items-stretch" aria-hidden="true">
+    <div className="flex h-[32px] w-[3px] items-stretch" aria-hidden="true">
       <div className="w-px bg-[#808080]" />
       <div className="w-px bg-white" />
     </div>
@@ -96,11 +114,42 @@ export default function Taskbar() {
     useWindowManager()
   const [time, setTime] = useState(getTime())
   const [open, setOpen] = useState(false)
+  const [anchorRect, setAnchorRect] = useState<DOMRect | null>(null)
+  const startButtonRef = useRef<HTMLButtonElement | null>(null)
 
   useEffect(() => {
     const id = setInterval(() => setTime(getTime()), 1000)
     return () => clearInterval(id)
   }, [])
+
+  useLayoutEffect(() => {
+    if (!open) {
+      setAnchorRect(null)
+      return
+    }
+
+    const button = startButtonRef.current
+    if (!button) return
+
+    const updateRect = () => {
+      setAnchorRect(button.getBoundingClientRect())
+    }
+
+    updateRect()
+
+    const resizeObserver =
+      typeof ResizeObserver !== 'undefined'
+        ? new ResizeObserver(() => updateRect())
+        : null
+
+    resizeObserver?.observe(button)
+    window.addEventListener('resize', updateRect)
+
+    return () => {
+      resizeObserver?.disconnect()
+      window.removeEventListener('resize', updateRect)
+    }
+  }, [open])
 
   const orderedWindows = useMemo(
     () => [...windows].sort((a, b) => a.zIndex - b.zIndex),
@@ -109,23 +158,23 @@ export default function Taskbar() {
 
   return (
     <div
-      className={`relative flex h-12 items-center gap-2 bg-[#C0C0C0] px-3 text-[13px] ${taskbarFrame}`}
+      className={`relative flex h-[40px] items-center gap-2 bg-[#C0C0C0] px-3 text-[13px] ${taskbarFrame}`}
     >
-      <StartButton open={open} onClick={() => setOpen(value => !value)} />
+      <StartButton
+        ref={startButtonRef}
+        open={open}
+        onClick={() => setOpen(value => !value)}
+      />
 
       <Divider />
 
-      <Frame
-        variant="well"
-        shadow
-        className="flex h-9 flex-1 items-center gap-1 overflow-x-auto overflow-y-hidden bg-[#BDBDBD] px-2"
-      >
+      <div className="flex h-9 flex-1 items-center gap-1 overflow-x-auto overflow-y-hidden border-t border-l border-white border-b-[2px] border-r-[2px] border-[#808080] bg-[#C0C0C0] px-2">
         {orderedWindows.map(window => {
           const definition = apps[window.appId]
           const isActive = activeWindowId === window.id && !window.minimized
 
           return (
-            <Button
+            <button
               key={window.id}
               onClick={() => {
                 if (window.minimized || isActive) {
@@ -134,41 +183,36 @@ export default function Taskbar() {
                   focusWindow(window.id)
                 }
               }}
-              active={isActive}
-              variant="thin"
-              className="flex h-7 min-w-[140px] flex-shrink-0 items-center gap-2 truncate bg-[#C0C0C0] px-3 text-left"
+              className={clsx(
+                'flex h-7 min-w-[140px] flex-shrink-0 items-center gap-2 truncate px-3 text-left text-[12px] font-semibold transition-colors',
+                isActive
+                  ? 'border-t border-l border-[#404040] border-b-[2px] border-r-[2px] border-white bg-[#9C9C9C] text-black shadow-[inset_1px_1px_0_0_#dfdfdf,inset_-1px_-1px_0_0_#808080]'
+                  : 'border-t border-l border-white border-b-[2px] border-r-[2px] border-[#404040] bg-[#C3C3C3] text-black hover:bg-[#d9d9d9]'
+              )}
             >
               <span aria-hidden>{definition?.icon ?? '🪟'}</span>
               <span className="truncate text-left">{window.title}</span>
-            </Button>
+            </button>
           )
         })}
-      </Frame>
+      </div>
 
       <Divider />
 
       <div className="flex h-9 items-center gap-2">
-        <Frame
-          variant="well"
-          shadow
-          className="flex h-full items-center gap-2 bg-[#C0C0C0] px-2"
-        >
+        <div className="flex h-full items-center gap-2 border-t border-l border-white border-b-[2px] border-r-[2px] border-[#808080] bg-[#C0C0C0] px-2">
           <MonitorIcon className="h-4 w-4" />
           <SpeakerIcon className="h-4 w-4" />
-        </Frame>
-        <Frame
-          variant="well"
-          shadow
-          className="flex h-full min-w-[88px] items-center justify-center bg-[#C0C0C0] px-3 font-['MS_Sans_Serif','Tahoma',sans-serif]"
-        >
+        </div>
+        <div className="flex h-full min-w-[88px] items-center justify-center border-t border-l border-white border-b-[2px] border-r-[2px] border-[#808080] bg-[#C0C0C0] px-3 font-['MS_Sans_Serif','Tahoma',sans-serif]">
           {time}
-        </Frame>
+        </div>
       </div>
 
       {open && (
         <>
           <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />
-          <StartMenu onClose={() => setOpen(false)} />
+          <StartMenu anchorRect={anchorRect} onClose={() => setOpen(false)} />
         </>
       )}
     </div>

--- a/src/components/components.test.ts
+++ b/src/components/components.test.ts
@@ -79,8 +79,10 @@ test('Meta renders', () => {
 })
 
 test('StartMenu renders', () => {
-  const html = withProvider(h(StartMenu, { onClose: () => {} }))
-  assert.ok(html.includes('Bugs'))
+  const html = withProvider(
+    h(StartMenu, { anchorRect: null, onClose: () => {} })
+  )
+  assert.ok(html.includes('Windows 95'))
 })
 
 test('Taskbar renders', () => {

--- a/src/index.css
+++ b/src/index.css
@@ -7,3 +7,24 @@
     height: 100%;
   }
 }
+
+@layer components {
+  .start-menu-shadow {
+    box-shadow: 4px 4px 0 rgba(0, 0, 0, 0.4);
+  }
+
+  .start-menu__brand {
+    padding-top: 8px;
+    padding-bottom: 8px;
+  }
+
+  .start-menu__brand-text {
+    writing-mode: vertical-rl;
+    transform: rotate(180deg);
+    font-family: 'MS Sans Serif', 'Tahoma', sans-serif;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+}


### PR DESCRIPTION
## Summary
- restyle the taskbar with custom Windows 95 start button, beveled task list, and tray widgets
- rebuild the start menu so it anchors to the start button and recreates the Win95 sidebar/branding
- add supporting CSS utilities and refresh documentation/tests for the new shell UI

## Testing
- npm run format
- npm run lint
- npm test
