### PR TITLE
Add Windows 95 Internet Explorer shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ This is a "bug bounty hackathon" project that ironically has more bugs than it f
 - 📂 **Start Menu**: Rebuilt with the teal sidebar, beveled casing, and Start button alignment from classic Windows 95 for quick navigation
 - 🗂️ **Desktop Shortcuts Everywhere**: Every page now shows up on the desktop for
   quick double-click access
+- 🌐 **Internet Explorer Shortcut**: Launch a faux Windows 95 browser that beams
+  you straight to techmap.dev without leaving the desktop nostalgia bubble
 - 🔍 **Search & Filter**: Hunt bugs and leaderboard entries like a pro
 - ⏰ **PTO Rewards**: Earn ridiculous amounts of time off for each bug you squash
 - 🧹 **Automatic Cleanup**: Squashed bugs vanish on their own, only to respawn

--- a/src/routes/InternetExplorer.tsx
+++ b/src/routes/InternetExplorer.tsx
@@ -1,0 +1,146 @@
+import { memo, useEffect, useState, type FC } from 'react'
+import { Button, Frame, TextInput } from 'react95'
+import Meta from '../components/Meta'
+import type { WindowComponentProps } from '../types/window'
+
+const HOMEPAGE_URL = 'https://techmap.dev/'
+const MENU_ITEMS = [
+  'File',
+  'Edit',
+  'View',
+  'Favorites',
+  'Tools',
+  'Help',
+] as const
+
+type LoadStatus = 'loading' | 'loaded' | 'timeout'
+
+const InternetExplorer: FC<WindowComponentProps> = ({ setTitle }) => {
+  const [status, setStatus] = useState<LoadStatus>('loading')
+  const [reloadKey, setReloadKey] = useState(0)
+
+  useEffect(() => {
+    if (setTitle) {
+      setTitle('Internet Explorer - techmap.dev')
+    }
+  }, [setTitle])
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || status !== 'loading') {
+      return undefined
+    }
+
+    const timeout = window.setTimeout(() => {
+      setStatus(prev => (prev === 'loading' ? 'timeout' : prev))
+    }, 6000)
+
+    return () => window.clearTimeout(timeout)
+  }, [status])
+
+  const handleReload = () => {
+    setStatus('loading')
+    setReloadKey(key => key + 1)
+  }
+
+  const handleOpenExternal = () => {
+    if (typeof window !== 'undefined') {
+      window.open(HOMEPAGE_URL, '_blank', 'noopener,noreferrer')
+    }
+  }
+
+  const statusLabel =
+    status === 'loaded'
+      ? 'Done'
+      : status === 'timeout'
+        ? 'Navigation canceled'
+        : 'Opening https://techmap.dev/...'
+
+  return (
+    <>
+      <Meta
+        title="Internet Explorer"
+        description="Browse techmap.dev inside our retro Windows 95 Internet Explorer shell."
+      />
+      <div className="flex h-full flex-col overflow-hidden bg-[#C0C0C0] text-black">
+        <div className="border-b border-[#808080] bg-[#C0C0C0] px-2 py-2 text-[13px]">
+          <div className="mb-2 flex items-center gap-3">
+            {MENU_ITEMS.map(item => (
+              <span key={item} className="cursor-default select-none">
+                {item}
+              </span>
+            ))}
+          </div>
+          <div className="mb-2 flex items-center gap-2">
+            <Button size="sm" disabled>
+              ◀
+            </Button>
+            <Button size="sm" disabled>
+              ▶
+            </Button>
+            <Button size="sm" onClick={handleReload}>
+              Refresh
+            </Button>
+            <Button size="sm" onClick={handleOpenExternal}>
+              Home
+            </Button>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-xs uppercase tracking-wide text-[#000080]">
+              Address
+            </span>
+            <Frame
+              variant="well"
+              className="flex flex-1 items-center bg-white px-2 py-1"
+            >
+              <TextInput value={HOMEPAGE_URL} readOnly fullWidth />
+            </Frame>
+            <Button size="sm" onClick={handleOpenExternal}>
+              Go
+            </Button>
+          </div>
+        </div>
+        <div className="relative flex-1 bg-white">
+          <iframe
+            key={reloadKey}
+            src={HOMEPAGE_URL}
+            title="techmap.dev"
+            className="h-full w-full border-0"
+            onLoad={() => setStatus('loaded')}
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; geolocation; gyroscope; picture-in-picture"
+          />
+          {status !== 'loaded' && (
+            <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-white/95 p-4 text-center text-sm">
+              <div className="font-semibold text-[#000080]">
+                Connecting to techmap.dev...
+              </div>
+              {status === 'timeout' ? (
+                <>
+                  <p className="max-w-xs text-xs text-[#404040]">
+                    Some modern sites block embedding inside classic browsers.
+                    Use the Go button to launch techmap.dev in a new window.
+                  </p>
+                  <Button size="sm" onClick={handleOpenExternal}>
+                    Open in new window
+                  </Button>
+                </>
+              ) : (
+                <p className="max-w-xs text-xs text-[#404040]">
+                  Spinning up a 90s-era modem...
+                </p>
+              )}
+            </div>
+          )}
+        </div>
+        <Frame
+          variant="well"
+          className="flex items-center justify-between bg-[#E0E0E0] px-2 py-1 text-xs"
+        >
+          <span>{statusLabel}</span>
+          <span>Internet</span>
+        </Frame>
+      </div>
+    </>
+  )
+}
+
+export default memo(InternetExplorer)

--- a/src/routes/pages.test.ts
+++ b/src/routes/pages.test.ts
@@ -9,6 +9,7 @@ import Dashboard from './Dashboard.tsx'
 import EasterEgg from './EasterEgg.tsx'
 import Fortune from './Fortune.tsx'
 import JobDescription from './JobDescription.tsx'
+import InternetExplorer from './InternetExplorer.tsx'
 import Leaderboard from './Leaderboard.tsx'
 import NewBug from './NewBug.tsx'
 import NotFound from './NotFound.tsx'
@@ -44,6 +45,11 @@ test('Fortune page renders', () => {
 test('JobDescription page renders', () => {
   const html = wrap(h(JobDescription))
   assert.ok(html.includes('Bug Basher Role'))
+})
+
+test('InternetExplorer page renders', () => {
+  const html = wrap(h(InternetExplorer))
+  assert.ok(html.includes('techmap.dev'))
 })
 
 test('Leaderboard page renders', () => {

--- a/src/types/window.ts
+++ b/src/types/window.ts
@@ -7,6 +7,7 @@ export type WindowAppId =
   | 'signUp'
   | 'newBug'
   | 'jobDescription'
+  | 'internetExplorer'
   | 'easterEgg'
   | 'userProfile'
   | 'notFound'

--- a/src/utils/window-apps.ts
+++ b/src/utils/window-apps.ts
@@ -25,6 +25,7 @@ const Fortune = lazy(() => import('../routes/Fortune'))
 const SignUp = lazy(() => import('../routes/SignUp'))
 const NewBug = lazy(() => import('../routes/NewBug'))
 const JobDescription = lazy(() => import('../routes/JobDescription'))
+const InternetExplorer = lazy(() => import('../routes/InternetExplorer'))
 const EasterEgg = lazy(() => import('../routes/EasterEgg'))
 const UserProfile = lazy(() => import('../routes/UserProfile'))
 const NotFound = lazy(() => import('../routes/NotFound'))
@@ -99,6 +100,15 @@ export const WINDOW_APPS: Record<WindowAppId, WindowAppDefinition> = {
     icon: '📄',
     Component: JobDescription,
     defaultSize: { width: 720, height: 640 },
+    desktopShortcut: true,
+    startMenuShortcut: true,
+  },
+  internetExplorer: {
+    id: 'internetExplorer',
+    title: 'Internet Explorer',
+    icon: '🌐',
+    Component: InternetExplorer,
+    defaultSize: { width: 960, height: 720 },
     desktopShortcut: true,
     startMenuShortcut: true,
   },


### PR DESCRIPTION
## Summary
- add a retro Internet Explorer window that opens techmap.dev and expose it as a desktop/start menu shortcut
- register the new app with the window manager typings and lazy loader
- document the new shortcut and cover it with the server-render smoke test

## Testing
- npm run format
- npm run lint
- npm test *(fails: node: bad option: --experimental-transform-types)*

------
https://chatgpt.com/codex/tasks/task_e_68c92016d780832aa3ac45a32cf02c0d