### PR TITLE
Improve Win95 window control icons

### DIFF
--- a/src/components/DesktopWindow.tsx
+++ b/src/components/DesktopWindow.tsx
@@ -5,6 +5,7 @@ import {
   Win95CloseIcon,
   Win95MaximizeIcon,
   Win95MinimizeIcon,
+  Win95RestoreIcon,
 } from './WindowControlIcons'
 import { useWindowManager } from '../contexts/WindowManagerContext'
 import { WINDOW_APPS } from '../utils/window-apps'
@@ -84,7 +85,11 @@ export default function DesktopWindow({ windowState, containerSize }: Props) {
               aria-label={windowState.maximized ? 'Restore' : 'Maximize'}
               onClick={handleMaximize}
             >
-              <Win95MaximizeIcon />
+              {windowState.maximized ? (
+                <Win95RestoreIcon />
+              ) : (
+                <Win95MaximizeIcon />
+              )}
             </Button>
             <Button
               square

--- a/src/components/WindowControlIcons.tsx
+++ b/src/components/WindowControlIcons.tsx
@@ -5,80 +5,125 @@ const HIGHLIGHT = '#FFFFFF'
 const SHADOW = '#808080'
 const FACE = '#C0C0C0'
 const OUTLINE = '#000000'
+const ACCENT_DARK = '#000080'
+const ACCENT_LIGHT = '#1084d9'
+const ICON_CLASS = 'block h-4 w-4'
+
+const svgBaseProps = {
+  viewBox: '0 0 16 16',
+  'aria-hidden': true,
+  focusable: 'false',
+  shapeRendering: 'crispEdges' as const,
+} satisfies SVGProps<SVGSVGElement>
 
 type IconProps = SVGProps<SVGSVGElement>
 
 export function Win95MinimizeIcon({ className, ...props }: IconProps) {
   return (
-    <svg
-      viewBox="0 0 12 12"
-      aria-hidden="true"
-      focusable="false"
-      shapeRendering="crispEdges"
-      className={clsx('h-3 w-3', className)}
-      {...props}
-    >
-      <rect x="2" y="7" width="8" height="1" fill={OUTLINE} />
-      <rect x="2" y="8" width="8" height="1" fill={SHADOW} />
+    <svg {...svgBaseProps} className={clsx(ICON_CLASS, className)} {...props}>
+      <rect x="3" y="10" width="10" height="3" fill={FACE} />
+      <rect x="3" y="10" width="10" height="1" fill={HIGHLIGHT} />
+      <rect x="3" y="11" width="10" height="1" fill={OUTLINE} />
+      <rect x="3" y="12" width="10" height="1" fill={SHADOW} />
+      <rect x="2" y="11" width="1" height="1" fill={HIGHLIGHT} />
+      <rect x="2" y="12" width="1" height="1" fill={HIGHLIGHT} />
+      <rect x="13" y="11" width="1" height="1" fill={OUTLINE} />
+      <rect x="13" y="12" width="1" height="1" fill={SHADOW} />
     </svg>
   )
 }
 
 export function Win95MaximizeIcon({ className, ...props }: IconProps) {
   return (
-    <svg
-      viewBox="0 0 12 12"
-      aria-hidden="true"
-      focusable="false"
-      shapeRendering="crispEdges"
-      className={clsx('h-3 w-3', className)}
-      {...props}
-    >
-      <rect x="2" y="2" width="8" height="6" fill={FACE} />
-      <path d="M2.5 2.5H9.5" stroke={HIGHLIGHT} strokeWidth="1" />
-      <path d="M2.5 2.5V7.5" stroke={HIGHLIGHT} strokeWidth="1" />
-      <path d="M2.5 7.5H9.5" stroke={OUTLINE} strokeWidth="1" />
-      <path d="M9.5 2.5V7.5" stroke={OUTLINE} strokeWidth="1" />
-      <rect x="3" y="3" width="6" height="4" fill={HIGHLIGHT} />
-      <path d="M3.5 3.5H8.5" stroke={OUTLINE} strokeWidth="1" />
-      <path d="M3.5 3.5V6.5" stroke={OUTLINE} strokeWidth="1" />
-      <path d="M3.5 6.5H8.5" stroke={SHADOW} strokeWidth="1" />
-      <path d="M8.5 3.5V6.5" stroke={SHADOW} strokeWidth="1" />
+    <svg {...svgBaseProps} className={clsx(ICON_CLASS, className)} {...props}>
+      <rect x="3" y="3" width="10" height="1" fill={OUTLINE} />
+      <rect x="3" y="3" width="1" height="8" fill={OUTLINE} />
+      <rect x="12" y="3" width="1" height="8" fill={OUTLINE} />
+      <rect x="3" y="10" width="10" height="1" fill={OUTLINE} />
+
+      <rect x="4" y="4" width="8" height="1" fill={HIGHLIGHT} />
+      <rect x="4" y="4" width="1" height="6" fill={HIGHLIGHT} />
+      <rect x="11" y="4" width="1" height="6" fill={SHADOW} />
+      <rect x="4" y="9" width="8" height="1" fill={SHADOW} />
+
+      <rect x="5" y="5" width="6" height="4" fill={FACE} />
+      <rect x="5" y="5" width="6" height="1" fill={ACCENT_LIGHT} />
+      <rect x="5" y="6" width="6" height="1" fill={ACCENT_DARK} />
+      <rect x="5" y="7" width="6" height="2" fill={FACE} />
+    </svg>
+  )
+}
+
+export function Win95RestoreIcon({ className, ...props }: IconProps) {
+  return (
+    <svg {...svgBaseProps} className={clsx(ICON_CLASS, className)} {...props}>
+      <rect x="4" y="4" width="8" height="1" fill={OUTLINE} />
+      <rect x="4" y="4" width="1" height="6" fill={OUTLINE} />
+      <rect x="11" y="4" width="1" height="6" fill={OUTLINE} />
+      <rect x="4" y="9" width="8" height="1" fill={OUTLINE} />
+
+      <rect x="5" y="5" width="6" height="1" fill={HIGHLIGHT} />
+      <rect x="5" y="5" width="1" height="4" fill={HIGHLIGHT} />
+      <rect x="10" y="5" width="1" height="4" fill={SHADOW} />
+      <rect x="5" y="8" width="6" height="1" fill={SHADOW} />
+      <rect x="5" y="6" width="6" height="2" fill={FACE} />
+
+      <rect x="6" y="6" width="4" height="1" fill={ACCENT_LIGHT} />
+      <rect x="6" y="7" width="4" height="1" fill={ACCENT_DARK} />
+
+      <rect x="6" y="6" width="8" height="1" fill={OUTLINE} />
+      <rect x="6" y="6" width="1" height="7" fill={OUTLINE} />
+      <rect x="13" y="6" width="1" height="7" fill={OUTLINE} />
+      <rect x="6" y="12" width="8" height="1" fill={OUTLINE} />
+
+      <rect x="7" y="7" width="6" height="1" fill={HIGHLIGHT} />
+      <rect x="7" y="7" width="1" height="5" fill={HIGHLIGHT} />
+      <rect x="12" y="7" width="1" height="5" fill={SHADOW} />
+      <rect x="7" y="11" width="6" height="1" fill={SHADOW} />
+      <rect x="7" y="8" width="6" height="3" fill={FACE} />
+
+      <rect x="8" y="8" width="4" height="1" fill={ACCENT_LIGHT} />
+      <rect x="8" y="9" width="4" height="1" fill={ACCENT_DARK} />
     </svg>
   )
 }
 
 export function Win95CloseIcon({ className, ...props }: IconProps) {
   return (
-    <svg
-      viewBox="0 0 12 12"
-      aria-hidden="true"
-      focusable="false"
-      shapeRendering="crispEdges"
-      className={clsx('h-3 w-3', className)}
-      {...props}
-    >
+    <svg {...svgBaseProps} className={clsx(ICON_CLASS, className)} {...props}>
       <path
-        d="M3.5 3.5L8.5 8.5"
+        d="M5 5L11 11"
         stroke={OUTLINE}
         strokeWidth="1"
         strokeLinecap="square"
       />
       <path
-        d="M3.5 8.5L8.5 3.5"
+        d="M5 11L11 5"
         stroke={OUTLINE}
         strokeWidth="1"
         strokeLinecap="square"
       />
       <path
-        d="M4.5 3.5L8.5 7.5"
+        d="M6 5L11 10"
         stroke={HIGHLIGHT}
         strokeWidth="1"
         strokeLinecap="square"
       />
       <path
-        d="M3.5 4.5L7.5 8.5"
+        d="M5 6L10 11"
         stroke={HIGHLIGHT}
+        strokeWidth="1"
+        strokeLinecap="square"
+      />
+      <path
+        d="M6 11L11 6"
+        stroke={SHADOW}
+        strokeWidth="1"
+        strokeLinecap="square"
+      />
+      <path
+        d="M5 10L10 5"
+        stroke={SHADOW}
         strokeWidth="1"
         strokeLinecap="square"
       />


### PR DESCRIPTION
## Summary
- rebuild the minimize, maximize, restore, and close icons as 16x16 Win95-style pixel art and share common svg props
- swap the maximize button to a restore icon whenever a window is maximized for better authenticity

## Testing
- npm run format
- npm run lint
- npm test *(fails: node: bad option: --experimental-transform-types / --test-coverage-include flags)*

------
https://chatgpt.com/codex/tasks/task_e_68c91fd42ec0832a84a50a039744dcca