### PR TITLE
Fix dashboard overflow for default window

### DIFF
--- a/src/routes/Dashboard.tsx
+++ b/src/routes/Dashboard.tsx
@@ -187,430 +187,437 @@ const Dashboard: FC<WindowComponentProps> = () => {
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 0.5 }}
+      className="flex h-full flex-col overflow-hidden"
     >
       <Meta
         title="Bug Dashboard - Stats and Progress"
         description="Track bug statistics, bounties and progress on the Bug Basher dashboard."
       />
-      {/* Header with title and date */}
-      <div className="mb-6 flex justify-between items-start">
-        <motion.div
-          initial={{ y: -20 }}
-          animate={{ y: 0 }}
-          transition={{ duration: 0.5 }}
-        >
-          <h1 className="text-3xl font-bold mb-1">Bug Bounty Dashboard</h1>
-          <p className="text-muted-foreground">
-            {new Date().toLocaleDateString('en-US', {
-              weekday: 'long',
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric',
-            })}
-          </p>
-        </motion.div>
+      <div className="min-w-0 flex-1 overflow-y-auto pr-4">
+        <div className="pb-6">
+          {/* Header with title and date */}
+          <div className="mb-6 flex justify-between items-start">
+            <motion.div
+              initial={{ y: -20 }}
+              animate={{ y: 0 }}
+              transition={{ duration: 0.5 }}
+            >
+              <h1 className="text-3xl font-bold mb-1">Bug Bounty Dashboard</h1>
+              <p className="text-muted-foreground">
+                {new Date().toLocaleDateString('en-US', {
+                  weekday: 'long',
+                  year: 'numeric',
+                  month: 'long',
+                  day: 'numeric',
+                })}
+              </p>
+            </motion.div>
 
-        <motion.div
-          initial={{ y: -20, opacity: 0 }}
-          animate={{ y: 0, opacity: 1 }}
-          transition={{ duration: 0.5, delay: 0.2 }}
-        >
-          <Button
-            className="flex items-center gap-2"
-            onClick={() => openWindow('newBug')}
-            primary
-          >
-            <BugIcon className="h-4 w-4" />
-            File a Bug
-          </Button>
-        </motion.div>
-      </div>
-
-      {/* Top stats */}
-      <div className="grid gap-6 md:grid-cols-3 mb-6">
-        <motion.div
-          whileHover={{ scale: 1.02 }}
-          transition={{ type: 'spring', stiffness: 300 }}
-        >
-          <Card
-            className={`bg-[#E0E0E0] ${raised} hover:${sunken} transition-all overflow-hidden`}
-          >
-            <div className="absolute -right-3 -top-3 h-16 w-16 bg-amber-100 rounded-full opacity-40"></div>
-            <CardHeader className="pb-2">
-              <CardTitle className="flex items-center gap-2">
-                <AlertTriangleIcon className="h-5 w-5 text-amber-500" />
-                Active Bugs
-              </CardTitle>
-              <CardDescription>Current unresolved bugs</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <motion.div
-                initial={{ scale: 0.8 }}
-                animate={{ scale: 1 }}
-                transition={{ type: 'spring', stiffness: 300 }}
-                className="text-3xl font-bold"
+            <motion.div
+              initial={{ y: -20, opacity: 0 }}
+              animate={{ y: 0, opacity: 1 }}
+              transition={{ duration: 0.5, delay: 0.2 }}
+            >
+              <Button
+                className="flex items-center gap-2"
+                onClick={() => openWindow('newBug')}
+                primary
               >
-                {stats.active}
-              </motion.div>
-            </CardContent>
-          </Card>
-        </motion.div>
+                <BugIcon className="h-4 w-4" />
+                File a Bug
+              </Button>
+            </motion.div>
+          </div>
 
-        <motion.div
-          whileHover={{ scale: 1.02 }}
-          transition={{ type: 'spring', stiffness: 300 }}
-        >
-          <Card
-            className={`bg-[#E0E0E0] ${raised} hover:${sunken} transition-all overflow-hidden`}
-          >
-            <div className="absolute -right-3 -top-3 h-16 w-16 bg-green-100 rounded-full opacity-40"></div>
-            <CardHeader className="pb-2">
-              <CardTitle className="flex items-center gap-2">
-                <CheckCircleIcon className="h-5 w-5 text-green-500" />
-                Squashed Bugs
-              </CardTitle>
-              <CardDescription>Successfully resolved bugs</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <motion.div
-                initial={{ scale: 0.8 }}
-                animate={{ scale: 1 }}
-                transition={{ type: 'spring', stiffness: 300 }}
-                className="text-3xl font-bold"
+          {/* Top stats */}
+          <div className="grid gap-6 md:grid-cols-3 mb-6">
+            <motion.div
+              whileHover={{ scale: 1.02 }}
+              transition={{ type: 'spring', stiffness: 300 }}
+            >
+              <Card
+                className={`bg-[#E0E0E0] ${raised} hover:${sunken} transition-all overflow-hidden`}
               >
-                {stats.squashed}
-              </motion.div>
-            </CardContent>
-          </Card>
-        </motion.div>
+                <div className="absolute -right-3 -top-3 h-16 w-16 bg-amber-100 rounded-full opacity-40"></div>
+                <CardHeader className="pb-2">
+                  <CardTitle className="flex items-center gap-2">
+                    <AlertTriangleIcon className="h-5 w-5 text-amber-500" />
+                    Active Bugs
+                  </CardTitle>
+                  <CardDescription>Current unresolved bugs</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <motion.div
+                    initial={{ scale: 0.8 }}
+                    animate={{ scale: 1 }}
+                    transition={{ type: 'spring', stiffness: 300 }}
+                    className="text-3xl font-bold"
+                  >
+                    {stats.active}
+                  </motion.div>
+                </CardContent>
+              </Card>
+            </motion.div>
 
-        <motion.div
-          whileHover={{ scale: 1.02 }}
-          transition={{ type: 'spring', stiffness: 300 }}
-        >
-          <Card
-            className={`bg-[#E0E0E0] ${raised} hover:${sunken} transition-all overflow-hidden`}
-          >
-            <div className="absolute -right-3 -top-3 h-16 w-16 bg-blue-100 rounded-full opacity-40"></div>
-            <CardHeader className="pb-2">
-              <CardTitle className="flex items-center gap-2">
-                <CrownIcon className="h-5 w-5 text-blue-500" />
-                Total Bounty
-              </CardTitle>
-              <CardDescription>Available + paid bounties</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <motion.div
-                initial={{ scale: 0.8 }}
-                animate={{ scale: 1 }}
-                transition={{ type: 'spring', stiffness: 300 }}
-                className="text-3xl font-bold"
+            <motion.div
+              whileHover={{ scale: 1.02 }}
+              transition={{ type: 'spring', stiffness: 300 }}
+            >
+              <Card
+                className={`bg-[#E0E0E0] ${raised} hover:${sunken} transition-all overflow-hidden`}
               >
-                {stats.totalBounty}
-              </motion.div>
-            </CardContent>
-          </Card>
-        </motion.div>
-      </div>
+                <div className="absolute -right-3 -top-3 h-16 w-16 bg-green-100 rounded-full opacity-40"></div>
+                <CardHeader className="pb-2">
+                  <CardTitle className="flex items-center gap-2">
+                    <CheckCircleIcon className="h-5 w-5 text-green-500" />
+                    Squashed Bugs
+                  </CardTitle>
+                  <CardDescription>Successfully resolved bugs</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <motion.div
+                    initial={{ scale: 0.8 }}
+                    animate={{ scale: 1 }}
+                    transition={{ type: 'spring', stiffness: 300 }}
+                    className="text-3xl font-bold"
+                  >
+                    {stats.squashed}
+                  </motion.div>
+                </CardContent>
+              </Card>
+            </motion.div>
 
-      {/* Middle section - stats & charts */}
-      <div className="grid gap-6 md:grid-cols-3 mb-6">
-        <Card className={`bg-[#E0E0E0] ${raised} md:col-span-1`}>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <TargetIcon className="h-5 w-5 text-purple-500" />
-              Resolution Progress
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-2">
-              <div className="flex justify-between">
-                <span>{stats.resolutionRate.toFixed(1)}% Complete</span>
-                <span>
-                  {squashedBugs.length}/{bugs.length} Bugs
-                </span>
-              </div>
-              <motion.div
-                initial={{ width: '0%' }}
-                animate={{ width: '100%' }}
-                transition={{ duration: 0.5 }}
+            <motion.div
+              whileHover={{ scale: 1.02 }}
+              transition={{ type: 'spring', stiffness: 300 }}
+            >
+              <Card
+                className={`bg-[#E0E0E0] ${raised} hover:${sunken} transition-all overflow-hidden`}
               >
-                <Progress value={stats.resolutionRate} className="h-2" />
-              </motion.div>
-            </div>
-          </CardContent>
-        </Card>
+                <div className="absolute -right-3 -top-3 h-16 w-16 bg-blue-100 rounded-full opacity-40"></div>
+                <CardHeader className="pb-2">
+                  <CardTitle className="flex items-center gap-2">
+                    <CrownIcon className="h-5 w-5 text-blue-500" />
+                    Total Bounty
+                  </CardTitle>
+                  <CardDescription>Available + paid bounties</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <motion.div
+                    initial={{ scale: 0.8 }}
+                    animate={{ scale: 1 }}
+                    transition={{ type: 'spring', stiffness: 300 }}
+                    className="text-3xl font-bold"
+                  >
+                    {stats.totalBounty}
+                  </motion.div>
+                </CardContent>
+              </Card>
+            </motion.div>
+          </div>
 
-        <Card className={`bg-[#E0E0E0] ${raised}`}>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <AreaChartIcon className="h-5 w-5 text-indigo-500" />
-              Bug Priority Distribution
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <PriorityChart bugs={activeBugs} />
-            <div className="flex justify-between mt-2 text-xs">
-              <span className="flex items-center">
-                <span className="h-2 w-2 bg-red-500 rounded-full mr-1"></span>
-                High
-              </span>
-              <span className="flex items-center">
-                <span className="h-2 w-2 bg-amber-500 rounded-full mr-1"></span>
-                Medium
-              </span>
-              <span className="flex items-center">
-                <span className="h-2 w-2 bg-blue-500 rounded-full mr-1"></span>
-                Low
-              </span>
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card className={`bg-[#E0E0E0] ${raised}`}>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <ZapIcon className="h-5 w-5 text-amber-500" />
-              Recent Activity
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <ActivityTimeline bugs={bugs} />
-          </CardContent>
-        </Card>
-      </div>
-
-      <BugTrendsChart bugs={bugs} />
-      <BugForecast bugs={bugs} />
-
-      {/* Top row stats */}
-      <div className="grid gap-6 md:grid-cols-2 mb-6">
-        <motion.div
-          initial={{ x: -20, opacity: 0 }}
-          animate={{ x: 0, opacity: 1 }}
-          transition={{ duration: 0.5 }}
-        >
-          <Card className={`bg-[#E0E0E0] ${raised} h-full`}>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <TrendingUpIcon className="h-5 w-5 text-indigo-500" />
-                Highest Bounty
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              {highestBountyBug ? (
+          {/* Middle section - stats & charts */}
+          <div className="grid gap-6 md:grid-cols-3 mb-6">
+            <Card className={`bg-[#E0E0E0] ${raised} md:col-span-1`}>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <TargetIcon className="h-5 w-5 text-purple-500" />
+                  Resolution Progress
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
                 <div className="space-y-2">
-                  <div className="flex justify-between items-center">
-                    <motion.span
-                      whileHover={{ scale: 1.05 }}
-                      className="font-medium"
-                    >
-                      {highestBountyBug.title}
-                    </motion.span>
-                    <Badge
-                      variant="outline"
-                      className="bg-green-100 font-semibold"
-                    >
-                      ${highestBountyBug.bounty}
-                    </Badge>
+                  <div className="flex justify-between">
+                    <span>{stats.resolutionRate.toFixed(1)}% Complete</span>
+                    <span>
+                      {squashedBugs.length}/{bugs.length} Bugs
+                    </span>
                   </div>
-                  <p className="text-sm text-muted-foreground">
-                    {highestBountyBug.description}
-                  </p>
-                  <div className="pt-2 flex justify-between items-center">
-                    <Badge
-                      variant="secondary"
-                      className={`${highestBountyBug.priority === 'high' ? 'bg-red-100' : highestBountyBug.priority === 'medium' ? 'bg-amber-100' : 'bg-blue-100'}`}
-                    >
-                      {highestBountyBug.priority} priority
-                    </Badge>
-                    <Button className="bg-[#C0C0C0] hover:bg-[#A0A0A0] text-black">
-                      View details
-                    </Button>
+                  <motion.div
+                    initial={{ width: '0%' }}
+                    animate={{ width: '100%' }}
+                    transition={{ duration: 0.5 }}
+                  >
+                    <Progress value={stats.resolutionRate} className="h-2" />
+                  </motion.div>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card className={`bg-[#E0E0E0] ${raised}`}>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <AreaChartIcon className="h-5 w-5 text-indigo-500" />
+                  Bug Priority Distribution
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <PriorityChart bugs={activeBugs} />
+                <div className="flex justify-between mt-2 text-xs">
+                  <span className="flex items-center">
+                    <span className="h-2 w-2 bg-red-500 rounded-full mr-1"></span>
+                    High
+                  </span>
+                  <span className="flex items-center">
+                    <span className="h-2 w-2 bg-amber-500 rounded-full mr-1"></span>
+                    Medium
+                  </span>
+                  <span className="flex items-center">
+                    <span className="h-2 w-2 bg-blue-500 rounded-full mr-1"></span>
+                    Low
+                  </span>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card className={`bg-[#E0E0E0] ${raised}`}>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <ZapIcon className="h-5 w-5 text-amber-500" />
+                  Recent Activity
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <ActivityTimeline bugs={bugs} />
+              </CardContent>
+            </Card>
+          </div>
+
+          <BugTrendsChart bugs={bugs} />
+          <BugForecast bugs={bugs} />
+
+          {/* Top row stats */}
+          <div className="grid gap-6 md:grid-cols-2 mb-6">
+            <motion.div
+              initial={{ x: -20, opacity: 0 }}
+              animate={{ x: 0, opacity: 1 }}
+              transition={{ duration: 0.5 }}
+            >
+              <Card className={`bg-[#E0E0E0] ${raised} h-full`}>
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2">
+                    <TrendingUpIcon className="h-5 w-5 text-indigo-500" />
+                    Highest Bounty
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  {highestBountyBug ? (
+                    <div className="space-y-2">
+                      <div className="flex justify-between items-center">
+                        <motion.span
+                          whileHover={{ scale: 1.05 }}
+                          className="font-medium"
+                        >
+                          {highestBountyBug.title}
+                        </motion.span>
+                        <Badge
+                          variant="outline"
+                          className="bg-green-100 font-semibold"
+                        >
+                          ${highestBountyBug.bounty}
+                        </Badge>
+                      </div>
+                      <p className="text-sm text-muted-foreground">
+                        {highestBountyBug.description}
+                      </p>
+                      <div className="pt-2 flex justify-between items-center">
+                        <Badge
+                          variant="secondary"
+                          className={`${highestBountyBug.priority === 'high' ? 'bg-red-100' : highestBountyBug.priority === 'medium' ? 'bg-amber-100' : 'bg-blue-100'}`}
+                        >
+                          {highestBountyBug.priority} priority
+                        </Badge>
+                        <Button className="bg-[#C0C0C0] hover:bg-[#A0A0A0] text-black">
+                          View details
+                        </Button>
+                      </div>
+                    </div>
+                  ) : (
+                    <p>No bugs available</p>
+                  )}
+                </CardContent>
+              </Card>
+            </motion.div>
+
+            <motion.div
+              initial={{ x: 20, opacity: 0 }}
+              animate={{ x: 0, opacity: 1 }}
+              transition={{ duration: 0.5, delay: 0.1 }}
+            >
+              <Card className={`bg-[#E0E0E0] ${raised} h-full`}>
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2">
+                    <RocketIcon className="h-5 w-5 text-pink-500" />
+                    Bug Insights
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="grid grid-cols-2 gap-4">
+                    <div className="border rounded p-3 flex flex-col items-center justify-center bg-white/50">
+                      <BugIcon className="h-6 w-6 mb-1 text-amber-500" />
+                      <span className="text-lg font-semibold">
+                        {Math.round(
+                          activeBountyTotal / (activeBugs.length || 1)
+                        )}
+                      </span>
+                      <span className="text-xs text-muted-foreground text-center">
+                        Avg. Bounty
+                      </span>
+                    </div>
+                    <div className="border rounded p-3 flex flex-col items-center justify-center bg-white/50">
+                      <TimerIcon className="h-6 w-6 mb-1 text-blue-500" />
+                      <span className="text-lg font-semibold">
+                        {activeBugs.filter(b => b.priority === 'high').length}
+                      </span>
+                      <span className="text-xs text-muted-foreground text-center">
+                        High Priority
+                      </span>
+                    </div>
                   </div>
-                </div>
-              ) : (
-                <p>No bugs available</p>
-              )}
-            </CardContent>
-          </Card>
-        </motion.div>
+                </CardContent>
+              </Card>
+            </motion.div>
+          </div>
 
-        <motion.div
-          initial={{ x: 20, opacity: 0 }}
-          animate={{ x: 0, opacity: 1 }}
-          transition={{ duration: 0.5, delay: 0.1 }}
-        >
-          <Card className={`bg-[#E0E0E0] ${raised} h-full`}>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <RocketIcon className="h-5 w-5 text-pink-500" />
-                Bug Insights
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="grid grid-cols-2 gap-4">
-                <div className="border rounded p-3 flex flex-col items-center justify-center bg-white/50">
-                  <BugIcon className="h-6 w-6 mb-1 text-amber-500" />
-                  <span className="text-lg font-semibold">
-                    {Math.round(activeBountyTotal / (activeBugs.length || 1))}
-                  </span>
-                  <span className="text-xs text-muted-foreground text-center">
-                    Avg. Bounty
-                  </span>
-                </div>
-                <div className="border rounded p-3 flex flex-col items-center justify-center bg-white/50">
-                  <TimerIcon className="h-6 w-6 mb-1 text-blue-500" />
-                  <span className="text-lg font-semibold">
-                    {activeBugs.filter(b => b.priority === 'high').length}
-                  </span>
-                  <span className="text-xs text-muted-foreground text-center">
-                    High Priority
-                  </span>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        </motion.div>
-      </div>
-
-      {/* Tabbed bug lists */}
-      <motion.div
-        initial={{ y: 20, opacity: 0 }}
-        animate={{ y: 0, opacity: 1 }}
-        transition={{ duration: 0.5, delay: 0.2 }}
-      >
-        <div className="flex flex-col md:flex-row gap-2 mb-4">
-          <TextInput
-            placeholder="Search bugs..."
-            value={searchTerm}
-            onChange={e => setSearchTerm(e.target.value)}
-            className="md:w-1/2"
-          />
-        </div>
-        <Tabs defaultValue="active" className="mb-6">
-          <TabsList
-            className={`mb-4 bg-[#C0C0C0]/80 p-1 w-full justify-start ${raised}`}
+          {/* Tabbed bug lists */}
+          <motion.div
+            initial={{ y: 20, opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            transition={{ duration: 0.5, delay: 0.2 }}
           >
-            <TabsTrigger
-              value="active"
-              className="data-[state=active]:bg-[#E0E0E0] data-[state=active]:text-black px-4 py-1"
-            >
-              Active Bugs
-            </TabsTrigger>
-            <TabsTrigger
-              value="squashed"
-              className="data-[state=active]:bg-[#E0E0E0] data-[state=active]:text-black px-4 py-1"
-            >
-              Squashed Bugs
-            </TabsTrigger>
-          </TabsList>
-
-          <TabsContent value="active">
-            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-              {filteredActiveBugs.map((bug, index) => (
-                <motion.div
-                  key={bug.id}
-                  initial={{ opacity: 0, y: 20 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ delay: index * 0.05 }}
-                  whileHover={{ scale: 1.02 }}
-                >
-                  <Card
-                    className={`bg-[#E0E0E0] ${raised} hover:${sunken} transition-all h-full`}
-                  >
-                    <CardHeader className="pb-2">
-                      <CardTitle className="flex justify-between items-start">
-                        <span>{bug.title}</span>
-                        <Badge
-                          variant="outline"
-                          className="ml-2 bg-green-100 font-semibold"
-                        >
-                          ${bug.bounty}
-                        </Badge>
-                      </CardTitle>
-                      {bug.priority && (
-                        <Badge
-                          variant="outline"
-                          className={`${
-                            bug.priority === 'high'
-                              ? 'text-red-500 border-red-500'
-                              : bug.priority === 'medium'
-                                ? 'text-amber-500 border-amber-500'
-                                : 'text-blue-500 border-blue-500'
-                          }`}
-                        >
-                          {bug.priority}
-                        </Badge>
-                      )}
-                    </CardHeader>
-                    <CardContent>
-                      <p className="text-sm">{bug.description}</p>
-                      {bug.createdAt && (
-                        <div className="flex items-center text-xs text-muted-foreground mt-2">
-                          <CalendarIcon className="mr-1 h-3 w-3" />
-                          Reported: {formatDate(new Date(bug.createdAt))}
-                        </div>
-                      )}
-                    </CardContent>
-                    <CardFooter className="flex justify-between">
-                      {bug.assignee && (
-                        <Badge variant="outline" className="text-xs">
-                          {bug.assignee}
-                        </Badge>
-                      )}
-                    </CardFooter>
-                  </Card>
-                </motion.div>
-              ))}
+            <div className="flex flex-col md:flex-row gap-2 mb-4">
+              <TextInput
+                placeholder="Search bugs..."
+                value={searchTerm}
+                onChange={e => setSearchTerm(e.target.value)}
+                className="md:w-1/2"
+              />
             </div>
-          </TabsContent>
-
-          <TabsContent value="squashed">
-            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-              {filteredSquashedBugs.map((bug, index) => (
-                <motion.div
-                  key={bug.id}
-                  initial={{ opacity: 0, y: 20 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ delay: index * 0.05 }}
-                  whileHover={{ scale: 1.02 }}
+            <Tabs defaultValue="active" className="mb-6">
+              <TabsList
+                className={`mb-4 bg-[#C0C0C0]/80 p-1 w-full justify-start ${raised}`}
+              >
+                <TabsTrigger
+                  value="active"
+                  className="data-[state=active]:bg-[#E0E0E0] data-[state=active]:text-black px-4 py-1"
                 >
-                  <Card
-                    className={`bg-[#E0E0E0] ${raised} hover:${sunken} transition-all h-full`}
-                  >
-                    <CardHeader className="pb-2">
-                      <CardTitle className="flex justify-between items-start">
-                        <span>{bug.title}</span>
-                        <Badge
-                          variant="outline"
-                          className="ml-2 bg-gray-100 font-semibold"
-                        >
-                          ${bug.bounty}
-                        </Badge>
-                      </CardTitle>
-                    </CardHeader>
-                    <CardContent>
-                      <p className="text-sm">{bug.description}</p>
-                      {bug.resolvedAt && (
-                        <div className="flex items-center text-xs text-muted-foreground mt-2">
-                          <CheckCircleIcon className="mr-1 h-3 w-3 text-green-500" />
-                          Resolved: {formatDate(new Date(bug.resolvedAt))}
-                        </div>
-                      )}
-                    </CardContent>
-                    <CardFooter className="flex justify-between items-center">
-                      <Badge className="bg-green-100 text-green-800 hover:bg-green-200">
-                        Squashed
-                      </Badge>
-                    </CardFooter>
-                  </Card>
-                </motion.div>
-              ))}
-            </div>
-          </TabsContent>
-        </Tabs>
-      </motion.div>
+                  Active Bugs
+                </TabsTrigger>
+                <TabsTrigger
+                  value="squashed"
+                  className="data-[state=active]:bg-[#E0E0E0] data-[state=active]:text-black px-4 py-1"
+                >
+                  Squashed Bugs
+                </TabsTrigger>
+              </TabsList>
+
+              <TabsContent value="active">
+                <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+                  {filteredActiveBugs.map((bug, index) => (
+                    <motion.div
+                      key={bug.id}
+                      initial={{ opacity: 0, y: 20 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      transition={{ delay: index * 0.05 }}
+                      whileHover={{ scale: 1.02 }}
+                    >
+                      <Card
+                        className={`bg-[#E0E0E0] ${raised} hover:${sunken} transition-all h-full`}
+                      >
+                        <CardHeader className="pb-2">
+                          <CardTitle className="flex justify-between items-start">
+                            <span>{bug.title}</span>
+                            <Badge
+                              variant="outline"
+                              className="ml-2 bg-green-100 font-semibold"
+                            >
+                              ${bug.bounty}
+                            </Badge>
+                          </CardTitle>
+                          {bug.priority && (
+                            <Badge
+                              variant="outline"
+                              className={`${
+                                bug.priority === 'high'
+                                  ? 'text-red-500 border-red-500'
+                                  : bug.priority === 'medium'
+                                    ? 'text-amber-500 border-amber-500'
+                                    : 'text-blue-500 border-blue-500'
+                              }`}
+                            >
+                              {bug.priority}
+                            </Badge>
+                          )}
+                        </CardHeader>
+                        <CardContent>
+                          <p className="text-sm">{bug.description}</p>
+                          {bug.createdAt && (
+                            <div className="flex items-center text-xs text-muted-foreground mt-2">
+                              <CalendarIcon className="mr-1 h-3 w-3" />
+                              Reported: {formatDate(new Date(bug.createdAt))}
+                            </div>
+                          )}
+                        </CardContent>
+                        <CardFooter className="flex justify-between">
+                          {bug.assignee && (
+                            <Badge variant="outline" className="text-xs">
+                              {bug.assignee}
+                            </Badge>
+                          )}
+                        </CardFooter>
+                      </Card>
+                    </motion.div>
+                  ))}
+                </div>
+              </TabsContent>
+
+              <TabsContent value="squashed">
+                <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+                  {filteredSquashedBugs.map((bug, index) => (
+                    <motion.div
+                      key={bug.id}
+                      initial={{ opacity: 0, y: 20 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      transition={{ delay: index * 0.05 }}
+                      whileHover={{ scale: 1.02 }}
+                    >
+                      <Card
+                        className={`bg-[#E0E0E0] ${raised} hover:${sunken} transition-all h-full`}
+                      >
+                        <CardHeader className="pb-2">
+                          <CardTitle className="flex justify-between items-start">
+                            <span>{bug.title}</span>
+                            <Badge
+                              variant="outline"
+                              className="ml-2 bg-gray-100 font-semibold"
+                            >
+                              ${bug.bounty}
+                            </Badge>
+                          </CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                          <p className="text-sm">{bug.description}</p>
+                          {bug.resolvedAt && (
+                            <div className="flex items-center text-xs text-muted-foreground mt-2">
+                              <CheckCircleIcon className="mr-1 h-3 w-3 text-green-500" />
+                              Resolved: {formatDate(new Date(bug.resolvedAt))}
+                            </div>
+                          )}
+                        </CardContent>
+                        <CardFooter className="flex justify-between items-center">
+                          <Badge className="bg-green-100 text-green-800 hover:bg-green-200">
+                            Squashed
+                          </Badge>
+                        </CardFooter>
+                      </Card>
+                    </motion.div>
+                  ))}
+                </div>
+              </TabsContent>
+            </Tabs>
+          </motion.div>
+        </div>
+      </div>
     </motion.div>
   )
 }


### PR DESCRIPTION
## Summary
- wrap the dashboard window content in a flex column with overflow handling so it stays within the default window size
- add a scrollable interior container to expose full dashboard content without resizing the window

## Testing
- npm run format
- npm run lint
- npm test *(fails: Node 20.19.4 does not recognize the repository's experimental CLI options)*

------
https://chatgpt.com/codex/tasks/task_e_68c91fb6ca54832aa5e99eaa12e61f37