### PR TITLE
Fix Bug Basher window layout so bugs render again

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ This is a "bug bounty hackathon" project that ironically has more bugs than it f
 ### 🎪 Features That Will Blow Your Mind (And Your Bundle Size)
 
 - 🐛 **Virtual Bug Extermination**: Because squashing real bugs requires actual skill
+- 🧼 **Bug Basher Arena Fix**: The playfield now stretches to fill the window again so the critters actually show up
 - 📊 **Dashboard with Fancy Charts**: D3.js charts now sport gradients, grids, and zoom
 - 🏆 **Leaderboard System**: Compete with yourself since you're probably the only user
 - 🎨 **Windows 95 UI**: Powered by React95 components so every window, button, and menu looks like it came straight from 1995

--- a/src/components/BugArea.tsx
+++ b/src/components/BugArea.tsx
@@ -320,7 +320,7 @@ const BugArea: React.FC<BugAreaProps> = ({ bugs }) => {
     <div
       ref={containerRef}
       onClick={shoot}
-      className="relative w-full h-full overflow-hidden select-none cursor-none"
+      className="absolute inset-0 overflow-hidden select-none cursor-none"
     >
       {/* Aim cross-hair */}
       <AimCursor x={aim.x} y={aim.y} />


### PR DESCRIPTION
## Summary
- anchor the BugArea component to fill its parent so the bug sprites can render again
- update the README feature list to mention the restored Bug Basher arena

## Testing
- npm run format
- npm run lint
- npm test *(fails: current Node.js v20.19.4 does not support the --experimental-transform-types and --test-coverage-include flags used by the test script)*

------
https://chatgpt.com/codex/tasks/task_e_68c91f9dd614832a87ba45c09197dc0c