### PR TITLE
Fix Internet Explorer window height

### DIFF
--- a/src/components/DesktopWindow.tsx
+++ b/src/components/DesktopWindow.tsx
@@ -101,7 +101,7 @@ export default function DesktopWindow({ windowState, containerSize }: Props) {
             </Button>
           </div>
         </WindowHeader>
-        <WindowContent className="flex-1 w-full overflow-hidden">
+        <WindowContent className="!h-full flex-1 w-full overflow-hidden">
           <Suspense
             fallback={
               <div className="flex h-full w-full items-center justify-center p-4">


### PR DESCRIPTION
## Summary
- enforce full-height React95 window content so apps like Internet Explorer fill their frames

## Testing
- npm run format
- npm run lint
- npm test *(fails: node bad option --experimental-transform-types)*

------
https://chatgpt.com/codex/tasks/task_e_68c98aaf5b4c832aa8fec3ef6d54443e