### PR TITLE
Left align Start menu items

### DIFF
--- a/src/components/StartMenu.tsx
+++ b/src/components/StartMenu.tsx
@@ -62,10 +62,13 @@ const StyledMenuList = styled(MenuList)`
 const StyledMenuItem = styled(MenuListItem)`
   display: flex;
   align-items: center;
+  justify-content: flex-start;
   gap: 8px;
   padding: 6px 10px;
   font-weight: 600;
   cursor: pointer;
+  text-align: left;
+  width: 100%;
 `
 
 const ItemIcon = styled.span`
@@ -77,6 +80,7 @@ const ItemLabel = styled.span`
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  text-align: left;
 `
 
 export default function StartMenu({ anchorRect, onClose }: StartMenuProps) {


### PR DESCRIPTION
## Summary
- ensure Start menu entries fill the menu width and align their contents to the left for consistency

## Testing
- npm run format
- npm run lint
- npm test *(fails: `node` in this environment does not recognize the experimental transform/types and test coverage flags required by the script)*

------
https://chatgpt.com/codex/tasks/task_e_68cf93c057b8832a8751827355ae74e1