### PR TITLE
Adjust Fortune Cookie window layout spacing

### DIFF
--- a/src/components/FortuneCookie.tsx
+++ b/src/components/FortuneCookie.tsx
@@ -22,6 +22,9 @@ const FortuneFrame = styled(Frame).attrs({
   display: flex;
   flex-direction: column;
   gap: 12px;
+  width: 100%;
+  max-width: 360px;
+  box-sizing: border-box;
 `
 
 const FortuneText = styled(Frame).attrs({ variant: 'well' as const })`

--- a/src/routes/Fortune.tsx
+++ b/src/routes/Fortune.tsx
@@ -8,11 +8,16 @@ const FortuneContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: 12px;
+  width: 100%;
+  padding: 16px;
+  align-items: center;
+  box-sizing: border-box;
 `
 
 const Title = styled.h1`
   margin: 0;
   font-size: 24px;
+  text-align: center;
 `
 
 const Fortune: FC<WindowComponentProps> = () => {


### PR DESCRIPTION
## Summary
- add padding and centering to the Fortune window container so the shell stays larger than its content
- constrain the Fortune Cookie frame width and box sizing to prevent overflow and center the title text

## Testing
- npm run format
- npm run lint
- npm test *(fails: node: bad option: --experimental-transform-types / coverage flags with current Node version)*


------
https://chatgpt.com/codex/tasks/task_e_68e4397bd20c832a8dfa695667ab6e47